### PR TITLE
Travis CI build script not working

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -4,5 +4,6 @@
 set -e
 
 # Do the magic
+bundle install --path vendor/bundle
 bundle exec jekyll build
 bundle exec htmlproofer ./_site --only-4xx --allow-hash-href true


### PR DESCRIPTION
The `cibuild` script now installs all the required gems before building the site.