### PR TITLE
Plugin was not supported

### DIFF
--- a/_layouts/articles.html
+++ b/_layouts/articles.html
@@ -15,17 +15,16 @@ layout: default
 
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
           <div class="page-header">
-            <h1>{{ page.title }}
-              <small class="page-author pull-right">by
-                {% assign authors = page.author | append: ',' | append: page.contrib | replace: ' ', '' | split: ',' %}
-                {% if authors %}
-                  {% for author in authors %}
-                    <a href="https://github.com/{{ author }}" data-toggle="tooltip" data-placement="bottom" title="{{ author }}">
-                    {% avatar user=author size=30 %}</a>
-                  {% endfor %}
-                {% endif %}
-              </small>
-            </h1>
+            <div class="page-author pull-right">by
+              {% assign authors = page.author | append: ',' | append: page.contrib | replace: ' ', '' | split: ',' %}
+              {% if authors %}
+                {% for author in authors %}
+                  <a href="https://github.com/{{ author }}" data-toggle="tooltip" data-placement="bottom" title="Visit {{ author }}'s on Github">
+                  @{{ author }}</a>
+                {% endfor %}
+              {% endif %}
+            </div>
+            <h1>{{ page.title }}</h1>
           </div><!-- /.page-header -->
 
           <!-- content -->


### PR DESCRIPTION
The `jekyll-avatar` plugin is not supported inside Github-pages, reverting to @ username.