### PR TITLE
M600 Filament Change documentation

### DIFF
--- a/_gcode/M600.md
+++ b/_gcode/M600.md
@@ -1,0 +1,80 @@
+---
+author: clexpert, petrzjunior
+category: [ 'gcode' ]
+
+
+title: Filament Change
+brief: Automatically change filament
+
+experimental: false
+since: 1.1.0-RC7
+group: filament
+
+codes:
+  - M600
+
+long:
+  - Retracts filament, lets user change it and that extrudes if user wants to. 
+
+notes:
+  - Command settings are set as parameters or in Configuration.h to use with LCD
+
+parameters:
+  -
+    tag: E
+    optional: true
+    description: Retract before moving to change position (negative)
+    values:
+      -
+        tag: pos
+        type: float
+        unit: mm
+  -
+    tag: L
+    optional: true
+    description: Load/unload lenght, longer for bowden (negative)
+    values:
+      -
+        tag: pos
+        type: float
+        unit: mm
+  -
+    tag: X
+    optional: true
+    description: X position for filament change
+    values:
+      -
+        tag: pos
+        type: float
+        unit: mm
+  -
+    tag: Y
+    optional: true
+    description: Y position for filament change
+    values:
+      -
+        tag: pos
+        type: float
+        unit: mm
+  -
+    tag: Z
+    optional: true
+    description: Z relative lift for filament change position
+    values:
+      -
+        tag: pos
+        type: float
+        unit: mm
+
+examples:
+  -
+    pre:
+      - The most common usage form is to use M600 without any arguments as it will follow the definitions set at compile time on the Configuration.h file.
+    code:
+      - M600 ; execute filament change
+  -
+    pre:
+      - 'To set change position may use the following:'
+    code:
+      - M600 X10 Y15 Z5 ; Do filament change at X:10, Y:15 and Z:+5 from current
+---


### PR DESCRIPTION
Add requested M600 Filament change documentation. Hope I have done everything correctly, if not correct me please.
I added it to new category named `filament`, where I would suggest putting future articles like manual filament change, filament runout etc. according to future `filament` singleton.

I also changed the template for G-Code to diplay author as other pages do. It doesn't break the design and seems helpful to me.