### PR TITLE
Adds G12 and G27 documentation

### DIFF
--- a/_gcode/G12.md
+++ b/_gcode/G12.md
@@ -1,0 +1,59 @@
+---
+title: Clean the Nozzle
+brief: Executes a predefined nozzle clean pattern
+
+experimental: true
+since: 1.1.0-RC7
+group: nozzle
+
+codes:
+  - G12
+
+long:
+  - Allows the user to start a nozzle cleaning process on demand by sending a G-Code command. Currently this command supports two different types of cleaning patterns, a stroke based one and a zig-zag like one. In order for this process to be effective is advisable to have a dedicated cleaning spot on the bed, or outside the bed but inside the reach of the nozzle.
+
+notes:
+  - 'Most of the default behavior is defined within `Configuration.h`, search for the options: `NOZZLE_CLEAN_STROKES`, `NOZZLE_CLEAN_START_POINT`, `NOZZLE_CLEAN_END_POINT` and `NOZZLE_CLEAN_PARK`.'
+  - 'When `NOZZLE_CLEAN_PARK` is enabled, Marlin will automatically move the nozzle back to the XYZ position from where `G12` was initially received.'
+
+parameters:
+  -
+    tag: P
+    optional: true
+    description: Pattern style selection
+    values:
+      -
+        tag: 0
+      -
+        tag: 1
+  -
+    tag: S
+    optional: true
+    description: Sets the number of strokes i.e. back-and-forth movements
+    values:
+      -
+        type: int
+
+  -
+    tag: T
+    type: int
+    optional: true
+    description: Sets the number of repetitions
+    values:
+      -
+        type: int
+
+
+examples:
+  -
+    pre:
+      The most basic example is to use the command without any arguments, this will default to a stroke based pattern which will be stroked `NOZZLE_CLEAN_STROKES` times.
+    code:
+      - G12 ; stroke pattern (default)
+  -
+    pre:
+      To generate a three triangle zig-zag pattern which will be stroked one time use the following command.
+    code:
+      - G12 P1 S1 T3 ; zig-zag pattern with three triangles
+
+---

--- a/_gcode/G27.md
+++ b/_gcode/G27.md
@@ -1,0 +1,46 @@
+---
+title: Park the nozzle
+brief: Moves the nozzle to a predefined position
+
+experimental: true
+since: 1.1.0-RC7
+group: nozzle
+
+codes:
+  - G27
+
+long:
+  - "Allows the user to define a special XYZ position, inside the machine's topology, to park the nozzle when idle or when receiving the `G27` G-Code command."
+
+notes:
+  - 'Most of the default behavior is defined within `Configuration.h`, search for the option `NOZZLE_PARK_POINT`.'
+
+parameters:
+  -
+    tag: P
+    optional: true
+    description: 'Z axis action'
+    values:
+      -
+        tag: 0
+        description: If current Z-pos is lower than Z-park then the nozzle will be raised to reach Z-park height
+      -
+        tag: 1
+        description: No matter the current Z-pos, the nozzle will be raised/lowered to reach Z-park height
+      -
+        tag: 2
+        description: The nozzle height will be raised by Z-park amount but never going over the machine's limit of `Z_MAX_POS`
+
+examples:
+  -
+    pre:
+      The most basic example is to use the command without any arguments, this will default to a move the the parking position and raising the Z-pos if lower than the default Z-park position.
+    code:
+      - G27 ; raise Z if lower
+  -
+    pre:
+      This one is useful to be used on the end-script of a print, it will raise the Z-pos by Z-park.
+    code:
+      - G27 P2 ; always raise Z
+
+---

--- a/_includes/gcode-info.html
+++ b/_includes/gcode-info.html
@@ -85,9 +85,7 @@ You're reading a document which has been marked as `needs-review`, this means th
                 -->{% else %}<!--
                   -->&lt;<!--
                   -->{% for pv in parm.values %}<!--
-                    -->{% if pv.description %}<!--
-                      --><span data-toggle="tooltip" data-placement="bottom" data-original-title="{{ pv.description }}">{% endif %}{{ pv.tag }}{% if pv.description %}</span><!--
-                    -->{% endif %}<!--
+                    -->{{ pv.tag }}<!--
                     -->{% if forloop.last != true %}<!--
                       -->&#x7C;<!--
                     -->{% endif %}<!--
@@ -151,9 +149,7 @@ You're reading a document which has been marked as `needs-review`, this means th
                         -->{% else %}<!--
                           -->&lt;<!--
                           -->{% for pv in parm.values %}<!--
-                            -->{% if pv.description %}<!--
-                              --><span data-toggle="tooltip" data-placement="bottom" data-original-title="{{ pv.description }}">{% endif %}{{ pv.tag }}{% if pv.description %}</span><!--
-                            -->{% endif %}<!--
+                            -->{{ pv.tag }}<!--
                             -->{% if forloop.last != true %}<!--
                               -->&#x7C;<!--
                             -->{% endif %}<!--
@@ -163,7 +159,19 @@ You're reading a document which has been marked as `needs-review`, this means th
                       -->{% endif %}<!--
                       -->{% if parm.optional == true%}&#x5D;{% else %}&gt;{% endif %}
                     </code></td>
-                    <td>{{ parm.description }}</td>
+                    <td>
+                      <p>{{ parm.description }}</p>
+                      {% if parm.values.size > 0 %}
+                        {% for pv in parm.values %}
+                          {% if pv.description %}
+                            <div class="custom-gcode-inline">
+                              <p><strong>{{ parm.tag }}{{ pv.tag }}:</strong></p>
+                              {{ pv.description | markdownify }}
+                            </div>
+                          {% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    </td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -67,6 +67,13 @@
   margin: 0px;
 }
 
+.custom-gcode-inline {
+  margin-bottom: 10px;
+}
+
+.custom-gcode-inline > p {
+  display: inline;
+}
 
 /*
  * Tagline


### PR DESCRIPTION
Adds G12 and G27 documentation.
Changes the gcode layout page to show individual options in the table view (have a look at G27.md for an example).