### PR TITLE
Added Marlin3DprinterTool to useful links for configuring a 3D printer

### DIFF
--- a/_development/configuration.md
+++ b/_development/configuration.md
@@ -36,6 +36,7 @@ If you've never calibrated a RepRap machine before, here are some links to resou
 -   [Calibration of your RepRap](https://sites.google.com/site/repraplogphase/calibration-of-your-reprap)
 -   [XY 20 mm Calibration Box](http://www.thingiverse.com/thing:298812)
 -   [G-Code reference](http://reprap.org/wiki/G-code)
+-   [Marlin3DprinterTool](https://github.com/cabbagecreek/Marlin3DprinterTool)
 
 The most important values to obtain are:
 


### PR DESCRIPTION
Marlin3dPrinterTool is a open-source software that helps you configure and test your 3D printer. The Software contains a "editor" that helps transfer settings from a working Marlin Firmware to a new. Its also possible to update the current Firmware and each update makes a comment with the old value. After changing its possible to open and run Arduino IDE from within the tool. (Arduino IDE must be installed and all librarys to Arduino must be installed)