### PR TITLE
Clarify Configure Board Model

### DIFF
--- a/_development/configuration.md
+++ b/_development/configuration.md
@@ -72,6 +72,8 @@ This defines which motherboard you used for your 3D printer. It tells Marlin to 
 
 Replace the `#define BOARD_RAMPS_14_EFB` line in Configuration.h with the line below that matches your current board.
 Check the `boards.h` file for the most up-to-date listing of supported boards, if you do not see yours listed here.
+NOTE: You MUST prefix the Board name with "MOTHERBOARD" in other words if you have done this correctly the line will read:
+#define MOTHERBOARD BOARD_RAMPS_14_EFB  43
 
 <table id="board_list" class="table table-condensed table-striped"></table>
 <script type="text/javascript">


### PR DESCRIPTION
This is to resolve an issue I had personally where I didn't realize that I needed to add the MOTHERBOARD class declaration as a prefix. I couldn't find any documentation that clarified this so I thought I'd add this change.