### PR TITLE
Add parameter S to M80 gcode

### DIFF
--- a/_gcode/M080.md
+++ b/_gcode/M080.md
@@ -18,6 +18,11 @@ notes:
   - Requires `POWER_SUPPLY` and a digital pin connected to the PSU's enable pin.
 
 parameters:
+  -
+    tag: S
+    optional: true
+    description: 'Report Power Supply state'
+    values:
 
 examples:
 


### PR DESCRIPTION
I add a line to describe "M80 S" new gcode command, to report power supply state.