### PR TITLE
Corrected G5 typo for P&Q description

### DIFF
--- a/_development/coding_standards.md
+++ b/_development/coding_standards.md
@@ -13,9 +13,9 @@ Please follow these formatting guidelines and coding standards when contributing
 ### Indentation
 Indentation is important for readability and maintainability of code, and provides guidance for naïve code editors (e.g., TextMate, Sublime, et. al.) to properly fold code blocks by level.
 
- - 2 spaces. Don't use tabs at all. _Set your editor to use spaces! Tabs will bite you in the end._
- - All blocks indented, including `#if` blocks and other non-brace compiler blocks
-<pre>
+ - Entab lines with 2 spaces and don't use tabs. _Set your editor to use 2 Spaces! Tabs will bite you in the end._
+ - All block elements should increase the indentation level, including `#if` blocks and other non-brace compiler blocks:
+```cpp
 void myFunction() {
   if (myCondition == 0) {
     #ifdef PETER_PARKER
@@ -25,47 +25,73 @@ void myFunction() {
     #endif
   }
 }
-</pre>
+```
 
-### Bracket-style
-We've chosen a bracket (i.e., ''brace'') style that shows the most code lines on screen, and which causes folded code blocks to appear at the end of the line where they begin. If vertical spacing makes code more readable, add a blank line rather than using a different bracket style.
+### Brace-style
+Marlin uses a brace style that maximizes the number of code lines on-screen, and which causes folded code blocks to appear at the end of the line where they begin. If vertical spacing makes code more readable, add a blank line rather than using a different bracket style.
 
- - "One True Bracket" Style – "1TBS" – to rule them all
- - Almost all opening braces at the end of lines, including declarations:
-<pre>
-if (...) {
-  ...
+ - "One True Bracket" Style – "1TBS" – to rule them all.
+ - Place opening braces at the end of lines, including in declarations.
+ - Closing braces should always align with the starting column of the opening line.
+
+Here's an example of 1TBS style applied to a faux function:
+```cpp
+void my_function(void) {
+  if (...) {
+    ...
+  }
+  else {
+    ...
+  }
+
+  switch (val) {
+    case 1: SERIAL_CHAR('Q'); break;
+    case 2: SERIAL_CHAR('T'); break;
+  }
 }
-else {
-  ...
-}
-</pre>
- - Closing braces should always align with the starting column of the opening line
+```
 
 ### Spacing
 
- - One space between keywords and their conditions:<br />`if (…)`, `while (…)`, `do {…} while(…)` etc.
- - No space between functions and their arguments:<br />`myFunction(…);`
- - Spaces between operators, most of the time:<br />`myVar = aVar + bVar * cVar;`<br />`myVal = (a*b + b*c); // grouping`
+ - Use one space between keywords and their conditions:<br />`if (…)`, `while (…)`, `do {…} while(…)` etc. No space is needed for `sizeof()` and other "function-like" built-ins.
+ - No spaces between functions and their arguments:<br />`myFunction(…);`
+ - No spaces around `.` or `->` operators.
+ - Use one space around (on each side of) most binary and ternary operators:<br />`myVar = aVar + bVar * cVar;`<br />`myVal = (a * b + b * c);`
 
-### Comments
+### Trailing Whitespace
 
- - Doxygen-style headings (documenting in .h files), C++ single-line style // for under 3 lines
- - Multi-line use asterisks in the second column
+Don't leave trailing whitespace at the ends of lines. Some editors will auto-indent new lines, leaving extra whitespace behind on blank lines. As a result, you end up with lines containing trailing whitespace.
+
+Git can warn you about patches that introduce trailing whitespace, and optionally strip the trailing whitespace for you; however, if applying a series of patches, this may make later patches in the series fail by changing their context lines.
+
+### Commenting
+
+Comments are good, but avoid over-commenting. _Never_ try to explain _how_ your code works in a comment: it's much better to write the code so that the working is obvious, and it's a waste of time to explain badly written code.
+
+Generally, you want your comments to explain _what_ your code does, not _how_. Keep comments inside a function body short. If a function is so complex that you need to separately comment parts of it, consider splitting it up into simpler units. Make small comments to note or warn about something particularly clever (or ugly), but avoid excess. Reserve detailed comments for the head of the function, telling people what it does, and possibly _why_ it does it.
+
+ - Use Doxygen-style comments for functions, classes, and other defined entities, and concentrate documentation in the `.h` files.
+```cpp
+/**
+ * This is the preferred style for multi-line comments in the
+ * Marlin Firmware source code. Please use it consistently.
+ *
+ * This mimics Doxygen/HeaderDoc style, and once keywords are added
+ * we'll be able to auto-generate code documentation and provide more
+ * complete development guidance.
+ */
+```
+- Use C++ single-line style with `//` for comments under 3 lines.
+```cpp
+// A short comment that takes up only a line or two
+// should just use end-of-line comment style.
+```
 
 ## Names and Symbols
-### Capitalization
-
- - `your_function_name(int in_integer, float in_float=0.0)`
- - `MyClass`
- - `ClassMethod`
- - `classData`
- - `local_variable`
- - `global_variable`
- - `MACRO_NAME` – anything created with `#define`
- - `EnumeratedType`
 
 ### Filenames
+
+Filenames for Marlin code should favor `lowercase_with_underscores.ext` format. Contributed code will follow its own standard.
 
  - use `.cpp` for C++ sources
  - use `.c` for C only sources
@@ -73,37 +99,77 @@ else {
 
 ### Directories
  - Lowercase names.
- - Note that Arduino cannot (easily) compile code in a sketch subfolder
+ - Marlin 1.0.x and 1.1.x retain a flat file layout
+ - Marlin 1.2.x and up adopts a hierarchical file layout
+
+### Capitalization
+
+For Marlin variables, data members, functions, and methods use `lowercase_with_underscores`. Use `camelCase` names only when class names and methods already uses that format. Marlin classes should use `my_class_name` format.
+
+ - `my_function_name(int in_integer, float in_float=0.0)`
+ - `MyClass`, `classMethod`, `classData`
+ - `local_variable`, `global_variable`, `const_value`
+ - `MACRO_NAME` – anything created with `#define`
+ - `EnumeratedType`
 
 ### Libraries
 
-Whenever possible use functions supplied by avr-libc or Arduino bundled libraries. Any libraries required to compile Marlin should be included in the package so that they are guaranteed to be compatible versions.
+Whenever possible, use the functions supplied by avr-libc or Arduino bundled libraries. Any libraries required to compile Marlin should be included in the package so that they are guaranteed to be compatible versions.
 
-## Extended Language Features
+## Language Features
 
-Marlin is written in C/C++ and must be able to compile with the supplied Makefile and an up-to-date version of Arduino. Backward-compatibility to earlier versions of Arduino is not required, but we can deal with this on an issue-to-issue basis.
+Marlin is written in C/C++ and needs be able to compile with the supplied `Makefile` or an up-to-date version of Arduino. With Marlin 1.1 we now support building with Arduino IDE, Teensyduino, PlatformIO, `make`, and `cmake`.
+
+Going forward, Marlin does not need to be backward-compatible with older (pre-2017) toolchains. The minimum requirement for Marlin 1.1.x is Arduino IDE 1.6.8.
+
+- **Do not use** extended C++ features like:
+    - Exceptions (throw / catch)
+    - Virtual functions / classes
+    - Standard Template Library (STL)
+
+- **Do use** modern C++11 features like:
+    - `constexpr` values and functions.
+    - `static_assert(test,"error")` to sanity-check `float` and `constexpr` values.
 
 ### Primitive Types
 
- - On AVR both `int` and `short` are 16-bits, and `long` is 32 bits.
+- Favor bit-size types like `uint8_t` and `int32_t` over `short`, `int`, and `long`. This helps to keep behavior consistent across architectures.
+- AVR recasts `double` as `float`, so both are 32 bits long. Favor `float` and avoid `double` unless the extra precision is needed on a 32-bit architecture.
 
 ### Memory Usage
 
- - DO NOT use dynamic memory allocations such as `malloc()`, `free()`, `new`, `delete`
- - ''(Some exceptions may be considered, with caveats!)''
+ - Dynamic allocation (`malloc()`, `free()`, `new`, `delete`) is ***verboten***!
+ - Avoid unconstrained recursion so the stack won't explode.
+ - Avoid using globals and `static` locals because SRAM is a precious resource.
+ - Use `PSTR` and `PROGMEM` macros to keep strings in Program Memory.
 
-### No Extended Features
+### Minimize Repetition
 
- - DO NOT use extended C++ features like:
-  * Exceptions (throw / catch)
-  * Virtual functions / classes
-  * Templates
-  * Standard Template Library (STL)
+When possible, use macros, small functions, and other clever techniques to avoid redundancy. For example, instead of this...
+```cpp
+#if ENABLED(FEATURE_ONE)
+  const char blue = '1';
+#else
+  const char blue = '0';
+#endif
+```
+...do this...
+```cpp
+const char blue =
+  #if ENABLED(FEATURE_ONE)
+    '1'
+  #else
+    '0'
+  #endif
+;
+```
 
 ### Avoid Expensive Code
 
- - `millis()` can be expensive so put it in a `uint32_t` if you need it more than once.
- - Pre-calculate if possible instead of calculating on the fly
+ - `millis()` can be expensive so put it in a `const millis_t var` if you need to use the value more than once. (And always use the `ELAPSED`/`PENDING` macros - see below.)
+ - Pre-calculate instead of calculating on the fly, when possible.
+ - Use multiplication (of the reciprocal) instead of division, when possible.
+ - Most code doesn't need to be optimized for speed, so favor smaller code.
 
 ## Marlin-specific Conventions
 
@@ -116,8 +182,71 @@ Marlin is written in C/C++ and must be able to compile with the supplied Makefil
  - Use `#define` macros to avoid repeating boilerplate code.<br />Consider both readability and maintainability.
  - Label `#endif` with the opening `#if` condition(s) if the block is over ~15 lines. Make the label compact. For example, `#endif // SDSUPPORT || ULTRALCD`.
 
+### Macros
+
+Marlin provides several shorthand macros in the `macros.h` file. Get to know them and use them. Here are some of the most common:
+
+- `ENABLED(OPTION)`/`DISABLED(OPTION)`: Test whether an option is on/off. Precompiler only.
+- `COUNT(array)`: Count the number of items in an array in-place. e.g., `for (i = 0; i < COUNT(my_arr); i++)`…
+- `WITHIN(var,low,high)`: Check that a variable is within a given range, inclusive.
+- `NUMERIC(c)`: Check whether a character is `0123456789`.
+- `DECIMAL(c)`: Check whether a character is `.0123456789`.
+- `NUMERIC_SIGNED(c)`: Check whether a character is `+-0123456789`.
+- `DECIMAL_SIGNED(c)`: Check whether a character is `+-.0123456789`.
+- `NOLESS(var,min)`: Constrain a variable to a minimum value.
+- `NOMORE(var,max)`: Constrain a variable to a maximum value.
+- `FORCE_INLINE`: Force a function or method to be compiled inline (almost like a macro).
+- `STRINGIFY(DEFINE)`: Resolve a define to a quoted string. (If undefined, the name of the define.)
+- `ARRAY_N(N,values)`: Expand into a prepopulated array of size N (based on an option like `EXTRUDERS`).
+- `PIN_EXISTS(NAME)`: True if the pin is defined. Precompiler only. (Takes the name minus `_PIN`.)
+- `NEAR_ZERO(V)`/`UNEAR_ZERO(V)`/`NEAR(V1,V2)`: Check whether a float value is very near zero or another value.
+- `RECIPROCAL(N)`: The reciprocal of a value, except return 0.0 (not infinity) for 0.0.
+- `RADIANS(d)`/`DEGREES(r)`: Convert degrees to radians and back again.
+- `FIXFLOAT(N)`: Add a tiny value to a float to compensate for rounding errors.
+- `NOOP`: A do-nothing macro to use for empty macro functions.
+
+### Time Comparison
+
+Use the following macros when comparing two millis count values:
+
+- `PENDING(ms,time)`: The `time` is pending, compared to `ms`.
+- `ELAPSED(ms,time)`: The `time` has elapsed, compared to `ms`.
+
+When using `ELAPSED` and `PENDING`, always compare against the _next time_ rather than the _last time_. This...
+```cpp
+const millis_t ms = millis();
+if (ELAPSED(ms, next_event_ms)) {
+  next_event_ms = ms + TIME_INTERVAL;
+  ...
+}
+```
+...will be smaller and faster than this...
+```cpp
+const millis_t ms = millis();
+if (ELAPSED(ms, last_event_ms + TIME_INTERVAL)) {
+  last_event_ms = ms;
+  ...
+}
+```
+
+### Serial Macros
+
+The `serial.h` file also includes several macros to make it easier to create PROGMEM strings and print them to the serial output. Below are a few of them. See the `serial.h` file for others.
+
+- `SERIAL_PROTOCOL("hello")`: Print an ASCII string stored in SRAM to serial out.
+- `SERIAL_PROTOCOLLN("hello")`: Print an ASCII string stored in SRAM to serial out, appending a newline.
+- `SERIAL_PROTOCOLPGM("hello")`: Wrap the given ASCII string in `PSTR` and print it to serial out.
+- `SERIAL_PROTOCOLLNPGM("hello")`: Wrap the given ASCII string in `PSTR` and print it to serial out, appending a newline.
+- `SERIAL_PROTOCOLPAIR("Hello:",val)`: Wrap an ASCII string in `PSTR`; print it and a value to serial out.
+- `SERIAL_PROTOCOLLNPAIR("Hello:",val)`: Wrap an ASCII string in `PSTR`; print it, a value, and a newline to serial out.
+- `SERIAL_ECHO_START()`: Send "`echo:`" to the serial output.
+- `SERIAL_ECHO(S)`, `SERIAL_ECHOLN(S)`, `SERIAL_ECHOPGM(S)`, etc., just like the `PROTOCOL_*` macros above.
+- `SERIAL_ERROR_START()`: Print "`error:`" to the serial output.
+- `SERIAL_ERROR(S)`, `SERIAL_ERRORLN(S)`, `SERIAL_ERRORPGM(S)`, etc.
+
 ### Adding a New Feature
-Since Marlin is an Arduino firmware and not a desktop application, much care has been taken to keep code size at a minimum, and to avoid using any features that may overtax the hardware, including demanding math operations. New features should try to conserve the limited resources available and allocate a fixed amount of memory (apart from `auto` variables) to do their work.
+
+Since Marlin needs to runs on the most modest hardware, much care has been taken to keep code size small and avoid overtaxing the CPU. AVR and some 32-bit CPUs have no FPU, so it's best to avoid floating point operations whenever possible, and add-on features should also conserve SRAM. Right out of the gate, the default configuration of Marlin 1.1 uses over 2.6K of SRAM, and won't fit on an UNO.
 
  - `#define` is used liberally, especially for configuration values
  - Use `#define MYFEATURE` for feature switches.
@@ -128,25 +257,25 @@ Since Marlin is an Arduino firmware and not a desktop application, much care has
 
 #### New Feature Example
 **In Configuration.h:**
-<pre>
+```cpp
 // Enable this to make something new happen
 #define MYFEATURE
 #if ENABLED(MYFEATURE)
   #define MYFEATURE_SETTING 12.5
   #undef OVERRIDDEN_FEATURE // This won't be needed with MYFEATURE
 #endif
-</pre>
+```
 **In SanityCheck.h:**
-<pre>
+```cpp
 /**
  * My feature
  */
 #if ENABLED(MYFEATURE) && ENABLED(INCOMPAT_FEATURE)
   #error MYFEATURE is not compatible with INCOMPAT_FEATURE
 #endif
-</pre>
+```
 **In Conditionals.h:**
-<pre>
+```cpp
 /**
  * My feature
  */
@@ -155,9 +284,9 @@ Since Marlin is an Arduino firmware and not a desktop application, much care has
   #undef OVERRIDDEN_SETTING // This setting will always be 1234 with MYFEATURE
   #define OVERRIDDEN_SETTING 1234
 #endif
-</pre>
+```
 **In Marlin_main.cpp, for example:**
-<pre>
+```cpp
 // My Feature, when Your Feature is disabled
 #if ENABLED(MYFEATURE) && DISABLED(YOURFEATURE)
   my_feature_function(); // Run my feature, possible an inline function taking refs
@@ -171,4 +300,4 @@ Since Marlin is an Arduino firmware and not a desktop application, much care has
     ...
   #endif // !HISFEATURE
 #endif // MYFEATURE
-</pre>
+```

--- a/_gcode/G005.md
+++ b/_gcode/G005.md
@@ -52,7 +52,7 @@ parameters:
   -
     tag: P
     optional: false
-    description: X incremental offset from start point to first control point
+    description: X incremental offset from end point to second control point
     values:
       -
         tag: pos
@@ -60,7 +60,7 @@ parameters:
   -
     tag: Q
     optional: false
-    description: Y incremental offset from start point to first control point
+    description: Y incremental offset from end point to second control point
     values:
       -
         tag: pos


### PR DESCRIPTION
According to [the documentation](http://linuxcnc.org/docs/2.6/html/gcode/gcode.html#sec:G5-Cubic-Spline) linked to in the source, it appears that P & Q should be listed as the "secondary offsets" that are relative to the "end point"