### PR TITLE
Update auto_bed_leveling.md

### DIFF
--- a/_features/auto_bed_leveling.md
+++ b/_features/auto_bed_leveling.md
@@ -47,7 +47,7 @@ Begin Automatic Bed Leveling with a plain `G29` command. This will use the setti
 If all goes well, move the nozzle down close to the bed and use a piece of paper to test the nozzle height. The paper should slide with a little bit of catch, but not too much. Now move the nozzle to different points on the bed with `G1` and re-test the height with the paper at each point. The feel should be close to the same at all points. If you find that the leveling isn't very accurate, use `M48` to test the accuracy of the bed probe.
 
 ## Bed Leveling and Printing
-Marlin is save the bed leveling results to EEPROM after each `G29` command. It will remain in memory until the next `G29` or homing by `G28`. After each `G28` a simple `M420 S1` will restore the saved mesh to memory. It is advised to set your slicer to add the `M420 S1` in the starting code.
+Marlin saves the bed leveling results to EEPROM after each `G29` command. It will remain in memory until the next `G29` or homing by `G28`. After each `G28` a simple `M420 S1` will restore the saved mesh to memory. It is advised to set your slicer to add the `M420 S1` in the starting code.
 
 In order to load the mesh from the printer boot up, after the `M420 S1` you can save this ABL active satus with `M500`. 
 

--- a/_features/auto_bed_leveling.md
+++ b/_features/auto_bed_leveling.md
@@ -7,18 +7,20 @@ category: [ features, leveling ]
 ---
 
 {% alert info %}
-This page is based on Marlin 1.1.2. Corrections/improvements are welcome.
+This article pertains to Marlin 1.1.6 and some earlier versions. Corrections/improvements are welcome.
 {% endalert %}
 
 {% alert info %}
-This page pertains to core Automatic Bed Leveling. Also soo [Unified Bed Leveling](unified_bed_leveling.html) and [Mesh Bed Leveling](/docs/gcode/G029-mbl.html).
+Marlin also includes [Unified Bed Leveling](unified_bed_leveling.html) and [Mesh Bed Leveling](/docs/gcode/G029-mbl.html) which have their own unique options. The information provided here does not fully apply to those features.
 {% endalert %}
 
 ## Introduction
 
 Automatic Bed Leveling (ABL) helps improve the quality of printing and bed adhesion by taking several measurements of the bed surface and then adjusting all movement to follow the tilt or contours of the bed. Most beds appear quite flat and even, but even when the bed is flat, there may be irregularities due to tape or other matter on the surface. Or there may be irregularities in the bed or nozzle height due to mechanical flaws. ABL is able to compensate for all these kinds of height irregularities.
 
-ABL requires a bed probe or some other mechanism to be able to test the bed height at various positions. Fortunately, probes come in many varieties, so there's a probe for every kind of printer. One popular solution is to use a mechanical switch mounted on a servo arm. The popular BLTouch probe emulates a servo but uses a retractable pin. There are infrared and inductive probes that trigger at some known distance from the bed. The nozzle itself may be used by mounting it on a spring-loaded carriage that presses a switch, or on a floating carriage that opens a contact.
+ABL requires a Bed Probe to automatically measure the bed height at various points. Fortunately, probes come in many varieties, so there's a probe for every kind of printer. One popular solution is to use a mechanical switch mounted on a servo arm. The popular BLTouch probe emulates a servo but uses a retractable pin. There are infrared and inductive probes that trigger at some known distance from the bed. The nozzle itself may be used by mounting it on a spring-loaded carriage that presses a switch, or on a floating carriage that opens a contact.
+
+Note that Marlin now includes a `PROBE_MANUALLY` option (described below) so if you don't have an electronic probe you can still use all forms of ABL.
 
 ## Types of Automatic Bed Leveling
  - Three-Point: Probe the bed at 3 arbitrary points and apply a matrix to the bed's overall tilt.
@@ -31,7 +33,7 @@ ABL requires a bed probe or some other mechanism to be able to test the bed heig
  - `AUTO_BED_LEVELING_LINEAR`
  - `AUTO_BED_LEVELING_BILINEAR`
 
-Unless you know you have a very flat bed, you should always use `AUTO_BED_LEVELING_BILINEAR`.
+Unless you know you have a very flat bed, you should always use `AUTO_BED_LEVELING_BILINEAR`. And if you have an LCD and enough program memory, you should also enable `LCD_BED_LEVELING` to add a **Bed Leveling** sub-menu to the LCD.
 
 2. Configure the points (for 3-point leveling) or boundaries (for the others) where probing will occur. For the grid-based leveling options specify how many points to probe in X and Y. These may be set to different values, but for a square bed they should be equal.
 
@@ -46,9 +48,14 @@ Begin Automatic Bed Leveling with a plain `G29` command. This will use the setti
 
 If all goes well, move the nozzle down close to the bed and use a piece of paper to test the nozzle height. The paper should slide with a little bit of catch, but not too much. Now move the nozzle to different points on the bed with `G1` and re-test the height with the paper at each point. The feel should be close to the same at all points. If you find that the leveling isn't very accurate, use `M48` to test the accuracy of the bed probe.
 
-## Bed Leveling and Printing
-Marlin saves the bed leveling results to EEPROM after each `G29` command. It will remain in memory until the next `G29` or homing by `G28`. After each `G28` a simple `M420 S1` will restore the saved mesh to memory. It is advised to set your slicer to add the `M420 S1` in the starting code.
+## Saving and Loading
+After a `G29` the leveling data is only stored in RAM. You have to use `M500` to save the bed leveling data to EEPROM, otherwise the data will be lost when you restart (or reconnect) the printer. Use `M502` to reset the bed leveling data (and other settings to defaults). Use `M501` to reload your last-saved bed leveling from EEPROM. This is done automatically on reboot.
 
-In order to load the mesh from the printer boot up, after the `M420 S1` you can save this ABL active satus with `M500`. 
+After a `G29` bed leveling is automatically enabled, but in all other situations you must use `M420 S1` to enable bed leveling. It is essential to include the command `M420 S1` in the "Start G-code" in your slicer settings. If you have no bed leveling, or if there is no leveling data, then this command is simply ignored.
 
-If using UBL instead of ABL, refer to the proper [Unified Bed Leveling](unified_bed_leveling.html) documentation and commands.
+## No Probe? No Problem!
+Marlin now includes a `PROBE_MANUALLY` option as a kind of faux probe. With this option enabled you send `G29` repeatedly, once for each point, until all points have been measured. In-between points you must manually adjust the Z axis with `G1` or your host software, feeling under the nozzle with a piece of paper or feeler gauge. Once the height feels right, send `G29` to move to the next point. This may take a while! When all points are done, be sure to save the results with `M500`.
+
+The `LCD_BED_LEVELING` option makes manual leveling a lot faster and easier by providing a guided procedure and direct Z adjustment.
+
+For even more exciting details about ABL, see the [`G29` Auto Bed Leveling](/docs/gcode/G029-abl.html) page.

--- a/_features/auto_bed_leveling.md
+++ b/_features/auto_bed_leveling.md
@@ -47,4 +47,8 @@ Begin Automatic Bed Leveling with a plain `G29` command. This will use the setti
 If all goes well, move the nozzle down close to the bed and use a piece of paper to test the nozzle height. The paper should slide with a little bit of catch, but not too much. Now move the nozzle to different points on the bed with `G1` and re-test the height with the paper at each point. The feel should be close to the same at all points. If you find that the leveling isn't very accurate, use `M48` to test the accuracy of the bed probe.
 
 ## Bed Leveling and Printing
-Currently, Marlin doesn't save the bed leveling results to EEPROM, and it throws away the probe results on `G28`. So the machine must always do a new `G29` after any `G28`. Marlin will be getting a Save Leveling function in the near future, and we'll make an announcement at that time.
+Marlin is save the bed leveling results to EEPROM after each `G29` command. It will remain in memory until the next `G29` or homing by `G28`. After each `G28` a simple `M420 S1` will restore the saved mesh to memory. It is advised to set your slicer to add the `M420 S1` in the starting code.
+
+In order to load the mesh from the printer boot up, after the `M420 S1` you can save this ABL active satus with `M500`. 
+
+If using UBL instead of ABL, refer to the proper [Unified Bed Leveling](unified_bed_leveling.html) documentation and commands.


### PR DESCRIPTION
Added the description of the  `M420 S1` command to load the `G29` ABL mesh saved in EEPROM. The documentation was prior to that function implementation.