### PR TITLE
Fix Liquid Syntax Error

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -12,7 +12,7 @@ layout: default
     <div class="row">
       <div class="col-lg-12">
         <div class="list-group">
-          {% assign list = ('' | split: '|') %}
+          {% assign list = '' | split: '|' %}
           {% for col in site.collections %}
             {% for doc in col.docs %}
               {% if doc.category %}
@@ -26,7 +26,7 @@ layout: default
           {% endfor %}
 
           {% if list.size > 0 %}
-            {% assign list = (list | sort: 'title') %}
+            {% assign list = list | sort: 'title' %}
             {% for doc in list %}
               <a href="{{ doc.url | prepend: site.baseurl }}" class="list-group-item">
                 <h4 class="list-group-item-heading">

--- a/_layouts/gcode.html
+++ b/_layouts/gcode.html
@@ -7,7 +7,7 @@ layout: default
   <div class="row">
     <div class="col-lg-3 col-md-4 visible-lg-block visible-md-block custom-no-padding">
       <div class="">
-        {% assign list = ('' | split: '|') %}
+        {% assign list = '' | split: '|' %}
         {% for gcode in site.gcode %}
           {% if gcode.codes[0] %}
             {% assign list = list | push: gcode %}
@@ -17,7 +17,7 @@ layout: default
         {% if list.size > 0 %}
           <div class="tocify gcode">
             <ul class="tocify-header nav nav-list">
-              {% assign list = (list | sort: 'tag') %}
+              {% assign list = list | sort: 'tag' %}
               {% for gcode in list %}
                   <li class="tocify-item{% if page.codes[0] == gcode.codes[0] and page.title == gcode.title %} active{% endif %}">
                     <a href="{{ gcode.url | prepend: site.baseurl }}">{{ gcode.codes[0] }}{% if gcode.codes[1] %}-{{ gcode.codes[1] }}{% endif %}: {{ gcode.title }}</a></li>


### PR DESCRIPTION
Fix to:
```
Liquid Warning: Liquid syntax error (line 6): Expected dotdot but found pipe in "{{('' | split: '|') }}" in /_layouts/gcode.html
Liquid Warning: Liquid syntax error (line 16): Expected dotdot but found pipe in "{{(list | sort: 'tag') }}" in /_layouts/gcode.html
Liquid Warning: Liquid syntax error (line 11): Expected dotdot but found pipe in "{{('' | split: '|') }}" in /_layouts/category.html
Liquid Warning: Liquid syntax error (line 25): Expected dotdot but found pipe in "{{(list | sort: 'title') }}" in /_layouts/category.htm
```
Using Liquid 4.0.0