### PR TITLE
Create M122.md

### DIFF
--- a/_gcode/M122.md
+++ b/_gcode/M122.md
@@ -71,7 +71,7 @@ examples:
       - s2ga
       - otpw
       - ot
-      - Driver registers:
+      - 'Driver registers:'
       - 	X = 0x80:0D:00:00
       - 	Y = 0x80:0D:00:00
       

--- a/_gcode/M122.md
+++ b/_gcode/M122.md
@@ -1,0 +1,79 @@
+---
+tag: m122
+title: TMC Debugging
+brief: Get TMC Debug Info
+author: mbuc
+
+experimental: false
+requires: HAVE_TMC2130,HAVE_TMC2208,TMC_DEBUG
+group: debug
+
+codes:
+  - M122
+
+long: 
+  - When sent without a parameter, returns a table of current register settings for any Trinamic TMC2130 or TMC2208 stepper motor drivers.  Sending the command with the `S` parameter and a following boolean will respectively enable or disable reporting the debugging information on a continous basis.
+
+notes:
+  - Need to have `TMC_DEBUG` enabled in `Configuration_adv.h`.
+
+parameters:
+  -
+    tag: S
+    type: boolean
+    optional: true
+    description: Flag to enable/disable continuous reporting of debugging information.
+
+examples:
+  -
+    pre:
+      - 'Enabling debugging output:'
+    code:
+      - M122 S1
+  -
+    pre:
+      - 'Example Output:'
+    code:
+      - SENDING:M122
+      - X	Y
+      - Enabled		false	false
+      - Set current	850	850
+      - RMS current	826	826
+      - MAX current	1165	1165
+      - Run current	26/31	26/31
+      - Hold current	13/31	13/31
+      - CS actual		13/31	13/31
+      - PWM scale	41	41
+      - vsense		1=.18	1=.18
+      - stealthChop	true	true
+      - msteps		16	16
+      - tstep		1048575	1048575
+      - pwm
+      - threshold		0	0
+      - [mm/s]		-	-
+      - OT prewarn	false	false
+      - OT prewarn has
+      - been triggered	false	false
+      - off time		5	5
+      - blank time	24	24
+      - hysterisis
+      - -end		2	2
+      - -start		3	3
+      - Stallguard thrs	0	0
+      - DRVSTATUS	X	Y
+      - stallguard
+      - sg_result		0	0
+      - fsactive
+      - stst		X	X
+      - olb
+      - ola
+      - s2gb
+      - s2ga
+      - otpw
+      - ot
+      - Driver registers:
+      - 	X = 0x80:0D:00:00
+      - 	Y = 0x80:0D:00:00
+      
+---
+


### PR DESCRIPTION
Looks like M122.md existed a while back for a different command.  M122, added in 1.1.6 or 1.1.7, allows the user to poll current settings for Trinamic TMC2208 or TMC2130 stepper motor drivers connected over SPI.

Please feel free to give feedback on formatting, I am still getting used to the markup language.