### PR TITLE
Clarify the use of `R` flag in the G29 UBL version

### DIFF
--- a/_gcode/G029-ubl.md
+++ b/_gcode/G029-ubl.md
@@ -146,7 +146,10 @@ parameters:
   -
     tag: R
     optional: true
-    description: Repeat count. (Default `GRID_MAX_POINTS_X * GRID_MAX_POINTS_Y`)
+    description: |
+      Repeat count. (Default `GRID_MAX_POINTS_X * GRID_MAX_POINTS_Y`). For example, in Phase 3, `G29 P3 R4 C0`- this will tell the firmware to fill the 4 closest points to the nozzle with a value of `0`. Or, in Phase 4, `G29 P4 R3 X80 Y80` - this will tell the firmware to allow you to tweak 3 points around [80,80].
+
+      _Note that the 'R' parameter does not work in Phase 1; the number of points probed automatically is always `GRID_MAX_POINTS_X * GRID_MAX_POINTS_Y`._
     values:
       -
         type: int


### PR DESCRIPTION
I think it was unclear how to use the R flag, and, specifically, that it cannot be used to adjust the mesh density on the fly (akin to the `P` flag for Linear ABL). As discussed at https://github.com/MarlinFirmware/Marlin/issues/9419.