### PR TITLE
Modified G26 sequence in example ubl

### DIFF
--- a/_features/unified_bed_leveling.md
+++ b/_features/unified_bed_leveling.md
@@ -40,39 +40,39 @@ The following command sequence can then be used as a quick-start guide to home, 
 ;------------------------------------------
 ;--- Setup and initial probing commands ---
 ;------------------------------------------
-M502          ; Reset settings to configuration defaults...
-M500          ; ...and Save to EEPROM. Use this on a new install.
-M501          ; Read back in the saved EEPROM.  
+M502            ; Reset settings to configuration defaults...
+M500            ; ...and Save to EEPROM. Use this on a new install.
+M501            ; Read back in the saved EEPROM.  
 
-M190 S65      ; Not required, but having the printer at temperature helps accuracy
-M104 S210     ; Not required, but having the printer at temperature helps accuracy
+M190 S65        ; Not required, but having the printer at temperature helps accuracy
+M104 S210       ; Not required, but having the printer at temperature helps accuracy
 
-G28           ; Home XYZ.
-G29 P1        ; Do automated probing of the bed.
-G29 P2 B T    ; Manual probing of locations USUALLY NOT NEEDED!!!!
-G29 P3 T      ; Repeat until all mesh points are filled in.
+G28             ; Home XYZ.
+G29 P1          ; Do automated probing of the bed.
+G29 P2 B T      ; Manual probing of locations USUALLY NOT NEEDED!!!!
+G29 P3 T        ; Repeat until all mesh points are filled in.
 
-G29 T         ; View the Z compensation values.
-G29 S1        ; Save UBL mesh points to EEPROM.
-G29 F 10.0    ; Set Fade Height for correction at 10.0 mm.
-G29 A         ; Activate the UBL System.
-M500          ; Save current setup. WARNING: UBL will be active at power up, before any `G28`.
+G29 T           ; View the Z compensation values.
+G29 S1          ; Save UBL mesh points to EEPROM.
+G29 F 10.0      ; Set Fade Height for correction at 10.0 mm.
+G29 A           ; Activate the UBL System.
+M500            ; Save current setup. WARNING: UBL will be active at power up, before any `G28`.
 ;---------------------------------------------
 ;--- Fine Tuning of the mesh happens below ---
 ;---------------------------------------------
-G26 C P T3.0  ; Produce mesh validation pattern with primed nozzle  PLA temperatures
-              ; are assumed unless you specify, e.g., B 105 H 225 for ABS Plastic
-G29 P4 T      ; Move nozzle to 'bad' areas and fine tune the values if needed
-              ; Repeat G26 and G29 P4 T  commands as needed.
+G26 C P5.0 F3.0 ; Produce mesh validation pattern with primed nozzle (5mm) and filament diameter 3mm 
+                ; PLA temperatures are assumed unless you specify, e.g., B 105 H 225 for ABS Plastic
+G29 P4 T        ; Move nozzle to 'bad' areas and fine tune the values if needed
+                ; Repeat G26 and G29 P4 T  commands as needed.
 
-G29 S1        ; Save UBL mesh values to EEPROM.
-M500          ; Resave UBL's state information.
+G29 S1          ; Save UBL mesh values to EEPROM.
+M500            ; Resave UBL's state information.
 ;----------------------------------------------------
 ;--- Use 3-point probe to transform a stored mesh ---
 ;----------------------------------------------------
-G29 L1        ; Load the mesh stored in slot 1 (from G29 S1)
-G29 J         ; No size specified on the J option tells G29 to probe the specified 3 points
-              ; and tilt the mesh according to what it finds.
+G29 L1          ; Load the mesh stored in slot 1 (from G29 S1)
+G29 J           ; No size specified on the J option tells G29 to probe the specified 3 points
+                ; and tilt the mesh according to what it finds.
 ```
 
 ### Scope


### PR DESCRIPTION
Removed invalid reference to C and replaced with F3.0
Primes the nozzle with 10mm, meaning no input is required from the LCD
in a full coverage bed

Resolves https://github.com/MarlinFirmware/MarlinDocumentation/issues/128