### PR TITLE
Update M43

### DIFF
--- a/_gcode/M043-T.md
+++ b/_gcode/M043-T.md
@@ -1,0 +1,72 @@
+---
+tag: m043b
+title: Toggle Details (Debug Pins)
+brief: Get information about pins.
+author: thinkyhead
+
+experimental: true
+requires: PINS_DEBUGGING
+group: debug
+
+codes:
+  - M43 T
+
+long:
+  - The M43 T command toggles one or more pins.
+
+notes:
+  - Requires `PINS_DEBUGGING`. This feature should be disabled for production use.
+
+parameters:
+  -
+    tag: S
+    optional: true
+    description: Start Pin number. If not given, will default to 0
+    values:
+      -
+        tag: pin
+        type: int
+  -
+    tag: L
+    optional: true
+    description: End Pin number. If not given, will default to last pin defined for this board
+    values:
+      -
+        tag: pin
+        type: int
+  -
+    tag: I
+    optional: true
+    description: Flag to ignore Marlin's pin protection. Use with caution!!!!
+    values:
+      -
+        type: bool    
+  -
+    tag: R
+    optional: true
+    description: Repeat pulses on each pin this number of times before continuing to next pin. If not given will default to 1.
+    values:
+      -
+        tag: count
+        type: int        
+  -
+    tag: W
+    optional: true
+    description: Wait time (in milliseconds) transitions. If not given will default to 500.
+    values:
+      -
+        tag: time
+        type: int       
+
+
+
+examples:
+  -
+    pre:
+      - Toggle pins 3-6 five times with 1 second low and 1 second high pulses but only if the pin isn't in the protected list.
+    code:
+      - M43 T S3 L6 R5 W1000
+
+
+---
+

--- a/_gcode/M043.md
+++ b/_gcode/M043.md
@@ -12,12 +12,11 @@ codes:
   - M43
 
 long:
-  - When setting up or debugging a machine it's useful to know how pins are assigned to functions by the firmware, and to be able to find pins for use with new functions. `M43` provides these tools. `M43` by itself reports all pin assignments. Use `P` to specify a single pin. Use `W` to watch the specified pin, or all pins. Use the `L` option to monitor endstops (Note: use `E` in firmware prior to 1.1.7).
+  - When setting up or debugging a machine it's useful to know how pins are assigned to functions by the firmware, and to be able to find pins for use with new functions. `M43` provides these tools. `M43` by itself reports all pin assignments. Use `P` to specify a single pin. Use `I` to report the values on pins that are protected. Use `W` to watch the specified pin, or all pins. Use the `E` option to monitor endstops. Use `S` option to test a BLTouch type servo probe.  Use `T` option to toggle pins.
   - The `W` watch mode option continues looping, blocking all further commands, until the board is reset. If `EMERGENCY_PARSER` is enabled, `M108` may also be used to exit the watch loop without needing to reset the board.
 
 notes:
   - Requires `PINS_DEBUGGING`. This feature should be disabled for production use.
-  - As of 1.1.7, the `E` parameter has been changed to `L` to match the behavior of Repetier Host.
 
 parameters:
   -
@@ -32,16 +31,29 @@ parameters:
     tag: W
     optional: true
     description: Watch pins
-    values:
-      -
-        type: bool
   -
-    tag: L
+    tag: E
     optional: true
     description: Watch endstops
     values:
       -
         type: bool
+  -
+    tag: T
+    optional: true
+    description: Toggle pins - see `M43 T` for options
+    values:
+  -
+    tag: S
+    optional: true
+    description: Test BLTouch type servo probes. Use `P` to specify servo index (0-3). Defaults to 0 if `P` omitted
+    values:
+  -
+    tag: I
+    optional: true
+    description: Ignore protection when reporting values
+    values:
+
 
 examples:
   -
@@ -51,6 +63,11 @@ examples:
       - M43
   -
     pre:
+      - Get a report on all pins, ignore pin protection list when displaying values
+    code:
+      - M43 I
+  -
+    pre:
       - Watch pin 56 for changes
     code:
       - M43 P56 W
@@ -58,7 +75,16 @@ examples:
     pre:
       - Start watching endstops
     code:
-      - M43 L
-
+      - M43 E1
+  -
+    pre:
+      - Toggle pins 3-6 five times with 1 second low and 1 second high pulses but only if the pin isn't in the protected list.
+    code:
+      - M43 T S3 L6 R5 W1000
+  -
+    pre:
+      - Test probe controlled by servo index 2.
+    code:
+      - M43 S P2     
 ---
 


### PR DESCRIPTION
Bring the M43 docs up to date with the current code.

Added Toggle and Servo tests and documented the I option.

Changed the Endstop test from "L" to "E" and removed the text about the "E" only applying to 1.1.7 and earlier.

The M43 T command has sub parameters.  This doesn't fit well with the G code template so I broke it out into a separate gcode file.  Even in a separate file it isn't a great fit.  I f I want the USAGE: section to say "M43 T" then the "codes" parameter has to say "M43 T".  That makes the index different than all the others. 