### PR TITLE
TMC update and review

### DIFF
--- a/_features/tmc_drivers.md
+++ b/_features/tmc_drivers.md
@@ -123,13 +123,13 @@ Command | Configuration<br>required | Description
 
 ## Troubleshooting
 
-- Use the latest **bugfix** firmware from github
-- Use the latest library versions
-- Check wiring and your wire grimps
-- Check **12V** (**24V**) power in the **Vm** pin and **5V** (**3.3V**) in the **Vio** pin
-- Check that configured pins match with your firmware configuration
-- Enable `TMC_DEBUG` and send `M122` to see the debugging output
-  - Reported register values of either `0x00000000` or `0xFFFFFFFF` are bad responses
+- Test the current **bugfix** branch of Marlin posted on GitHub (in case your issue is already fixed).
+- Use the latest TMC Stepper libraries.
+- Check all wiring and wire crimps.
+- Check **12V** (**24V**) power in the **Vm** pin and **5V** (**3.3V**) in the **Vio** pin.
+- Check that configured pins match your firmware configuration.
+- Enable `TMC_DEBUG` and send `M122` to see the debugging output.
+  - Reported register values of either `0x00000000` or `0xFFFFFFFF` are bad responses.
 - Try the examples provided by the respective library. Please detach any belts beforehand however, as the examples will not respect any endstop signals or physical limits. You may need to change the pin definitions.
 
 ## External resources

--- a/_features/tmc_drivers.md
+++ b/_features/tmc_drivers.md
@@ -99,7 +99,7 @@ HYBRID_THRESHOLD          | Configure the axis speed when the driver should swit
 SENSORLESS_HOMING         | Use the TMC drivers that support this feature to act as endstops by using stallGuard to detect a physical limit.
 HOMING_SENSITIVITY        | The Sensorless Homing sensitivity can be tuned to suit the specific machine.<br>A **higher** value will make homing **less** sensitive.<br>A **lower** value will make homing **more** sensitive.
 TMC_DEBUG                 | Enable M122 debugging command. This will give you _a lot_ of additional information about the status of your TMC drivers.
-TMC_ADV                   | You can use this to add your own configuration settings. The requirement is that the command used must be part of the respective TMC stepper library. Remember to add a backslash after every command!
+TMC_ADV                   | You can use this to add your own configuration settings. The requirement is that the command used must be part of the respective TMC stepper library. Remember to add a backslash after each command!
 
 ## GCodes
 
@@ -124,7 +124,9 @@ Command | Configuration<br>required | Description
 ## Troubleshooting
 
 - Use the latest **bugfix** firmware from github
+- Use the latest library versions
 - Check wiring and your wire grimps
+- Check **12V** (**24V**) power in the **Vm** pin and **5V** (**3.3V**) in the **Vio** pin
 - Check that configured pins match with your firmware configuration
 - Enable `TMC_DEBUG` and send `M122` to see the debugging output
   - Reported register values of either `0x00000000` or `0xFFFFFFFF` are bad responses
@@ -136,6 +138,10 @@ Command | Configuration<br>required | Description
 
 [Arduino library for TMC2208](https://github.com/teemuatlut/TMC2208Stepper)
 
+[SilentStepStick TMC2130 schematic and pinout](https://github.com/watterott/SilentStepStick/blob/master/hardware/SilentStepStick-TMC2130_v11.pdf)
+
+[SilentStepStick TMC2208 schematic and pinout](https://github.com/watterott/SilentStepStick/blob/master/hardware/SilentStepStick-TMC2208_v12.pdf)
+
 [Trinamic.com](https://www.trinamic.com)
 
 [Watterott documentation](http://learn.watterott.com/silentstepstick/)
@@ -146,6 +152,12 @@ Command | Configuration<br>required | Description
 
 [spreadCycle](https://www.trinamic.com/technology/adv-technologies/spreadcycle/)
 
-[Hackaday article by Moritz Walter](https://hackaday.com/2016/09/30/3d-printering-trinamic-tmc2130-stepper-motor-drivers-shifting-the-gears/)
+[TMC2130 datasheet](https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC2130_datasheet.pdf)
+
+[TMC2208 datasheet](https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC220x_TMC222x_Datasheet.pdf)
+
+[TMC2130 Hackaday article by Moritz Walter](https://hackaday.com/2016/09/30/3d-printering-trinamic-tmc2130-stepper-motor-drivers-shifting-the-gears/)
 
 [Video guide by Thomas Sanladerer](https://www.youtube.com/watch?v=sPvTB3irCxQ)
+
+[TMC2208 Torque testing by Alex Kenis](https://www.youtube.com/watch?v=GVs2d-TOims)

--- a/_gcode/M915.md
+++ b/_gcode/M915.md
@@ -14,7 +14,7 @@ codes:
 long: |
   The command aims to align the ends of the X gantry (for a Průša i3-style printer). Here's a [video demonstration](https://www.youtube.com/watch?v=JqH41K2vq0g&t=300s).
 
-  Using the given current, Marlin will move the Z axis (at homing speed) to the top plus a given extra distance. _Since this intentionally grinds the Z steppers, you should use the minimum current required to move the axis._
+  Using the given current, Marlin will move the Z axis (at homing speed) to the top plus a given extra distance. _Since this intentionally stalls the Z steppers, you should use the minimum current required to move the axis._
 
   Z is then re-homed to correct the position.
 

--- a/_gcode/M915.md
+++ b/_gcode/M915.md
@@ -12,15 +12,18 @@ codes:
   - M915
 
 long: |
-  Using the given current, move the Z axis (at homing speed) to the top plus a given extra distance. _This intentionally grinds the Z steppers._
+  The command aims to align the ends of the X gantry (for a Průša i3-style printer). Here's a [video demonstration](https://www.youtube.com/watch?v=JqH41K2vq0g&t=300s).
+
+  The current used should be close to the minimum that still allows the motors and the axis to move.
+  A low current prevents unnessary forces applied to the frame and for the feature to work we intentionally want to lose steps at the end of the raise move.
+
+  Using the given current, Marlin will move the Z axis (at homing speed) to the top plus a given extra distance. _This intentionally grinds the Z steppers._
 
   Z is then re-homed to correct the position.
 
-  This command serves two purposes:
-  - To align the ends of the X gantry (for a Průša i3-style printer). Here's a [video demonstration](https://www.youtube.com/watch?v=JqH41K2vq0g&t=300s).
-  - To help you find the optimal current setting for your Z drivers.
-
-notes: Requires `TMC_Z_CALIBRATION`.
+notes:
+  - Requires `TMC_Z_CALIBRATION` and at least one TMC driver for Z axis.
+  - If `Z_DUAL_STEPPER_DRIVERS` is used, both should be TMC drivers.
 
 parameters:
   -
@@ -42,9 +45,9 @@ parameters:
 
 example:
   -
-    pre: Set the current to 100mA and grind the steppers for 5mm.
+    pre: Set the current to 300mA and grind the steppers for 5mm.
     code:
       - G21 ; Units to mm
-      - M915 S100 Z5
+      - M915 S300 Z5
 
 ---

--- a/_gcode/M915.md
+++ b/_gcode/M915.md
@@ -14,10 +14,7 @@ codes:
 long: |
   The command aims to align the ends of the X gantry (for a Průša i3-style printer). Here's a [video demonstration](https://www.youtube.com/watch?v=JqH41K2vq0g&t=300s).
 
-  The current used should be close to the minimum that still allows the motors and the axis to move.
-  A low current prevents unnessary forces applied to the frame and for the feature to work we intentionally want to lose steps at the end of the raise move.
-
-  Using the given current, Marlin will move the Z axis (at homing speed) to the top plus a given extra distance. _This intentionally grinds the Z steppers._
+  Using the given current, Marlin will move the Z axis (at homing speed) to the top plus a given extra distance. _Since this intentionally grinds the Z steppers, you should use the minimum current required to move the axis._
 
   Z is then re-homed to correct the position.
 
@@ -45,7 +42,7 @@ parameters:
 
 example:
   -
-    pre: Set the current to 300mA and grind the steppers for 5mm.
+    pre: Set the current to 300mA and press the steppers against the top for an extra 5mm.
     code:
       - G21 ; Units to mm
       - M915 S300 Z5


### PR DESCRIPTION
Added some troubleshooting tips and a few additional resource links.

Reviewed M915. I removed the references to current calibration as that is not the intent of the command. When running the command, we want to use the absolute minimum current to prevent forces to the frame and leadscrews as well as promote skipped steps. This minimal current wouldn't be suitable for normal printing as here we don't have to deal with jerk and/or accelerations.

It might be good to add a sanity check for the `Z_DUAL_STEPPER_DRIVERS`. In a situation like that, we need current control for both the drivers.