### PR TITLE
Update M428.md

### DIFF
--- a/_gcode/M428.md
+++ b/_gcode/M428.md
@@ -14,6 +14,7 @@ codes:
 long: |
   Use `M428` to set a persistent offset to the native home position and coordinate space by assigning the current position as the native home position. See the example below.
 
+  - current position must be within 2cm from 0 or an endstop.
   - The current position is set to the native home position.
   - Any previous position shift from `G92` is cleared.
   - The home offset is persistent — added to the current position until changed.

--- a/_gcode/M428.md
+++ b/_gcode/M428.md
@@ -14,7 +14,7 @@ codes:
 long: |
   Use `M428` to set a persistent offset to the native home position and coordinate space by assigning the current position as the native home position. See the example below.
 
-  - current position must be within 2cm from 0 or an endstop.
+  - The current position must be within 2cm from 0 or an endstop.
   - The current position is set to the native home position.
   - Any previous position shift from `G92` is cleared.
   - The home offset is persistent — added to the current position until changed.


### PR DESCRIPTION
mention the 2cm limit like in Marlin_main.cpp:
```

  /**
   * M428: Set home_offset based on the distance between the
   *       current_position and the nearest "reference point."
   *       If an axis is past center its endstop position
   *       is the reference-point. Otherwise it uses 0. This allows
   *       the Z offset to be set near the bed when using a max endstop.
   *
   *       M428 can't be used more than 2cm away from 0 or an endstop.
   *
   *       Use M206 to set these values directly.
   */
```