### PR TITLE
Code quote within a code block doesn't work

### DIFF
--- a/_gcode/G029-ubl.md
+++ b/_gcode/G029-ubl.md
@@ -393,7 +393,7 @@ examples:
       G29 S1        ; Save UBL mesh points to EEPROM.
       G29 F 10.0    ; Set Fade Height for correction at 10.0 mm.
       G29 A         ; Activate the UBL System.
-      M500          ; Save current setup. WARNING - UBL will be active at power up, before any `G28`.
+      M500          ; Save current setup. WARNING - UBL will be active at power up, before any G28.
   -
     pre: Use `G26` and `G29` commands to fine-tune a measured mesh
     code: |


### PR DESCRIPTION
It will just will show ` ` ` marks.