### PR TITLE
Add auto-build PlatformIO instructions, re-organize Getting Started

### DIFF
--- a/_basics/Re-ARM.md
+++ b/_basics/Re-ARM.md
@@ -1,6 +1,6 @@
 ---
-title:        Installing Marlin 2.0 with PlatformIO
-description:  Marlin 2 Installation Quick Start Guide
+title:        Bringing up Re-ARM
+description:  Re-ARM specific hardware and software setup
 
 author: ModMike
 contrib: thinkyhead
@@ -27,7 +27,7 @@ On 32-bit boards the onboard SD card is used to store to the board's operating s
 
 **Important:**  If your SD card is larger than 32GB, _it must be partitioned_ so that the first partion is no larger than 32GB. The other partitions don't matter. Please refer to your system's tools or do a web search for "partition SD card."
 
-1. Format a 32GB SD card as FAT32 and name it "`rearm`".
+1. Format a 32GB SD card as FAT32 and name it "`REARM`".
 
 2. Insert the card into the Re-Arm's onboard SD card slot.
 
@@ -35,16 +35,16 @@ On 32-bit boards the onboard SD card is used to store to the board's operating s
 
 4. Connect the board to the computer using a USB cable.
 
-If all is well an SD card volume named "`rearm`" will appear on your Desktop (and/or the file browser).
+If all is well an SD card volume named "`REARM`" will appear on your Desktop (and/or the file browser).
 
 *If you've given the card a different name or if it uses a different system, you will need to know the exact logical path to the drive. Don't worry about this for now. It will be described in the **[Build Marlin](#build-marlin)** section below.*
 
 ## Install PlatformIO
 
-The PlatformIO IDE is distributed as a plugin for Google's ***Atom*** and Microsoft's **Visual Studio Code** (aka ***VSCode***). Both editors have a robust plugin architecture that allows them to become full-featured integrated development environments (IDEs) for PlatformIO. Instructions for installation are at the following links:
+See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
 
-- [Installing PlatformIO IDE in ***Atom***](http://docs.platformio.org/en/latest/ide/atom.html#installation)
-- [Installing PlatformIO IDE in ***VSCode***](http://docs.platformio.org/en/latest/ide/vscode.html#installation).
+This method is recommended because it is relatively easy and closely parallels this document.
+
 
 ## Download Marlin 2.0
 
@@ -58,64 +58,14 @@ _Pro Tip: If you're using **GitHub Desktop** to manage your own Marlin fork, sim
 
 ## Open Marlin in PlatformIO IDE
 
-1. At this point you may already have the project editor running. If not, go ahead and launch ***Atom*** or ***VSCode***.
+1. At this point you may already have the project editor running. If not, go ahead and launch ***Atom***.
 
-2. The "**PlatformIO Home**" page should appear. If not, click on the **Home** icon located in the top-left corner (***Atom***) or the bottom status bar (***VSCode***).
+2. The "**PlatformIO Home**" page should appear. If not, click on the **Home** icon located in the top-left corner.
 
 3. Click the "**Open Project**" button under "**Quick Access**."
 
 4. In the file dialog, navigate to the `MarlinFirmware` folder you created earlier, highlight it, and click the "**Open**" button. The project folder and its contents should appear in the Project navigator on the left side.
 
-## Get the SD card device path
-
-It is critical to have the correct path to your device. This procedure covers both logical devices and/or upload ports. The easiest way to do that is from the **PlatformIO Home** (**PIO Home**) page.
-
-Be sure that your board is connected and its volume is visible in the file browser sidebar and/or desktop. If it's a device port only, make sure that the system detected it.
-
-1. Click on the **Devices** icon on the left side of the PlatformIO Home page.
-
-2. A new pane will open with three tabs labeled **Serial**, **Logical**, and **Multicast DNS**.
-
-3. If the serial device is properly connected, it will appear in the **Port** list under the **Serial** tab.
-
-For a "Logical" drive (e.g., Re-Arm and most 32-bit boards) click on the **Logical** tab to list all devices. You should see the `rearm` SD card and possibly some other mounted volumes.
-
-4. Once you've identified the correct Serial port or Logical drive, click on the little blue page icon next to the item you want to use. This will copy its path to the clipboard. We recommend pasting the path into a new text file (`Ctrl-N` or `Cmd-N`) for later use.
-
-## Set Default Environment (optional)
-
-This part is optional, but it makes it easier to build for Re-Arm going forward. If you prefer to skip this section, scroll down to the next step, [Prepare Configuration](#prepare-configurationh).
-
-1. Under project on the left, find the `platform.ini` file and click on it to open it in the editor. Find the line starting with `env_default` and change the line to:
-
-    ```ini
-    env_default = LPC1768
-    ```
-
-2. In `platform.ini` locate the section that starts with `[env:LPC1768]`. Anywhere within this block of lines, insert the following line:
-
-    ```ini
-    upload_port = /Volumes/REARM
-    ```
-  (Assuming you've named the SD card "`rearm`".)
-
-3. Save the file.
-
-### For other boards…
-
-1. Under project on the left, find the `platform.ini` file and click on it to open it in the editor. Find the line starting with `env_default` and change the line to:
-
-    ```ini
-    env_default = name-of-your-env
-    ```
-
-2. Same as Step 2 above, but use the name of the SD card you set for your alternate board.
-
-    ```ini
-    upload_port = path-or-port-copied-from-devices
-    ```
-
-3. Save the file.
 
 # Prepare `Configuration.h`
 
@@ -149,27 +99,41 @@ The "EFB" acronym in the board name refers to _Extruder_, _Fan_, and _Bed_. This
 
 # Build Marlin
 
-1. Click on **PIO Build** in the bottom left (***Atom***) or choose **Run Build Task…** from the **Tasks** menu (***VSCode***) to bring up the dialog.
+## Method 1 - Preferred
 
-2. If you set the [default environment](#set-default-environment-optional) earlier, simply select "**PIO Build**" from the list. If you skipped that step, you'll need to scroll down and select "**PIO Build (LPC1768)**". (You can also type out "LPC17...", use the arrow keys, and press return.)
+See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
+
+## Method 2
+
+1. Click on **PIO Build** in the bottom left to bring up the dialog.
+
+2. Scroll down and select "**PIO Build (LPC1768)**". (You can also type out "LPC17...", use the arrow keys, and press return.)
 
 3. The build window will open and Marlin will be compiled. (This may take a minute or two.) If the build is successful, the window will close and the `firmware.bin` file will be saved in the `.pioenvs/LPC1768` folder.
 
 ### For other boards…
 
-You probably guessed that you would have to scroll to and pick "PIO Build your env_name". BUT if you did the optional step, you get to pick "PIO Build"!
+You probably guessed that you would have to scroll to and pick "PIO Build your env_name".
 
 # Upload Marlin
 
+Methods 1 and 2, after a successful run, will result in the `firmware.bin` file being in the `.pioenvs/LPC1768` folder ***and*** on the SD card on the Re-Arm board..
+
+If `firmware.bin` isn't on the SD card then either rerun the Method or use Method 3 to manually move the file onto the SD card.
+
 ## Method 1 - Preferred
 
-1. Click on **PIO Build** in the bottom left (***Atom***) or choose **Run Task** from the Tasks menu (***VSCode***) to bring up the dialog.
+See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
 
-2. If you set the [default environment](#set-default-environment-optional) earlier, simply select "**PIO Upload**" from the list. If you skipped that step, you'll need to scroll down and select "**PIO Upload (LPC1768)**". (You can also type out "LPC17...", use the arrow keys, and press return.)
+## Method 2
+
+1. Click on **PIO Build** in the bottom left to bring up the dialog.
+
+2. Scroll down and select "**PIO Upload (LPC1768)**". (You can also type out "LPC17...", use the arrow keys, and press return.)
 
 3. Wait while Marlin is compiled and uploaded. (This may take a few minutes.)
 
-## Method 2
+## Method 3
 
 If there is a properly formatted SD card in your Re-Arm board and the board is powered on, you should see it on the desktop and in the file browser. You don't need to remove the card from the Re-Arm and insert it into your computer, although that works too.
 
@@ -187,11 +151,11 @@ Note that this method requires accessing a hidden directory containing the `firm
 
 1. Push the reset button on the Re-Arm board to register your new build.
 
-2. Wait until the SD card named "`rearm`" reappears on your desktop and use the file browser to open the card and verify that the `FIRMWARE.CUR` and `eprom.dat` files were created.
+2. Wait until the SD card named "`REARM`" reappears on your desktop and use the file browser to open the card and verify that the `FIRMWARE.CUR` file was created.
 
-If you don't see these files, you'll need to do a hard reset by unplugging the USB cable, counting to 10, and plugging the USB cable back in.
+If you don't see this file, you'll need to do a hard reset by unplugging the USB cable, counting to 10, and plugging the USB cable back in.
 
-If you you see the files but still have issues, simply delete the files, empty the Recycle Bin (or Trash) and power-cycle the controller.
+If you see the file but still have issues, simply delete the file, empty the Recycle Bin (or Trash) and power-cycle the controller.
 
 ## Test the install
 
@@ -205,68 +169,6 @@ For the first test build you should have used the default `Configuration.h` and 
 
 We strongly suggest rebuilding your configs using one of the included example configs located in the **Marlin/src/config/examples** folder as a starting-point by first copying the appropriate files into the `MarlinFirmware/Marlin` folder. For much of this process, you can use the File Compare feature of ***Atom*** or ***VSCode***. Note that this won't help with any renamed or moved items.
 
-If you absolutely must port your existing configuration options from Marlin 1.1.x, you'll need to make a few changes. Some of the more common changes are detailed below.
-
-1. Start by copying your old `Configuration.h` and `Configuration_adv.h` files to the `MarlinFirmware/Marlin` folder, replacing the existing files. (Don't worry. Copies of these files are also located in `config/default`.)
-
-2. From ***Atom*** or ***VSCode***, open the `Configuration.h` file and change the configuration version number line to:
-
-    ```
-    #define CONFIGURATION_H_VERSION 020000
-    ```
-
-3. Find the `SERIAL_PORT` options and define them as shown here. You can copy and paste the text below if needed.
-
-    ```
-    #define SERIAL_PORT 0
-
-    /**
-     * Select a secondary serial port on the board to use for communication with the host.
-     * This allows the connection of wireless adapters (for instance) to non-default port pins.
-     * Serial port -1 is the USB emulated serial port, if available.
-     *
-     * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
-     */
-    #define SERIAL_PORT_2 -1
-
-    /**
-     * This setting determines the communication speed of the printer.
-     *
-     * 250000 works in most cases, but you might try a lower speed if
-     * you commonly experience drop-outs during host printing.
-     * You may try up to 1000000 to speed up SD file transfer.
-     *
-     * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
-     */
-    #define BAUDRATE 250000
-    ```
-
-4. As before, set `MOTHERBOARD` to the appropriate item from `boards.h`.
-
-    ```
-    #define MOTHERBOARD BOARD_RAMPS_14_RE_ARM_EFB
-    ```
-
-5. Find `ENDSTOP_INTERRUPTS_FEATURE` and disable it by commenting it out.
-
-    ```
-    //#define ENDSTOP_INTERRUPTS_FEATURE
-    ```
-***Note: As of this writing, endstop interrupts are not fully implemented. They are used to save CPU cycles but ARM processors have plenty of overhead so this isn't a concern.***
-
-6. You may or may not need to disable the piezo speaker.
-
-    ```
-    //#define SPEAKER
-    ```
-
-# Troubleshooting
-
-If you have issues building, pay close attention to the error messages. Marlin offers guidance on options whose names or values need to be changed to comply with Marlin 2.0. If you get unusual errors, be sure to [report them](https://github.com/MarlinFirmware/Marlin/issues/new) to the Marlin project on GitHub.
-
-If you get a lot of confusing build errors (and not very helpful ones) you may want to build a configuration by hand starting with the example files.
-
-_You can use any file comparison ("diff") tool (**Atom**, **VSCode**, **Notepad++**, or even **GitHub Desktop**) to compare your custom configurations to the original configurations from Marlin 1.1.x to see only the options you changed._
 
 # The main event!
 

--- a/_basics/install_Arduino.md
+++ b/_basics/install_Arduino.md
@@ -1,5 +1,5 @@
 ---
-title:        Installing Marlin
+title:        Installing Marlin using Arduino
 description:  Marlin Installation Quick Start Guide
 
 author: jbrazio
@@ -25,12 +25,17 @@ Link|Description
 ----|-----------
 [Download 1.1.x](https://github.com/MarlinFirmware/Marlin/archive/1.1.x.zip)|The current release version
 [Download 1.0.x](https://github.com/MarlinFirmware/Marlin/archive/1.0.x.zip)|The previous release version
-[Download bugfix-1.1.x](https://github.com/MarlinFirmware/Marlin/archive/bugfix-1.1.x.zip)|The "nightly" build version
+[Download bugfix-1.1.x](https://github.com/MarlinFirmware/Marlin/archive/bugfix-1.1.x.zip)|The "nightly" build version — Cutting-edge code! Beware!
+[Download bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip)|The "nightly" build version - Bleeding-edge code! Caution!
 
-If the latest Marlin requires too much Program Memory or SRAM to run on your legacy board, first try disabling some features to reclaim space. Then, if necessary, try an older version such as [1.0.2-2](https://github.com/MarlinFirmware/Marlin/archive/1.0.2-2.zip) or [1.0.1](https://github.com/MarlinFirmware/Marlin/archive/1.0.1.zip). (Older versions of Marlin have fewer global variables and therefore use less SRAM.)
+If the latest Marlin requires too much Program Memory or SRAM to run on your legacy board, first try disabling some features to reclaim space. Next, try the 2.0 codebase. Then, if necessary, try an older version such as [1.0.2-2](https://github.com/MarlinFirmware/Marlin/archive/1.0.2-2.zip) or [1.0.1](https://github.com/MarlinFirmware/Marlin/archive/1.0.1.zip). (Older versions of Marlin have fewer global variables and therefore use less SRAM.)
 
 {% alert warning %}
 Your printer may require a non-standard Arduino core (e.g., *Sanguino*, *Teensy++*) or additional libraries. See [Configuring Marlin](/docs/configuration/configuration.html) and commentary in `Configuration.h`/`Configuration_adv.h` pertaining to your hardware and add-ons. Each feature provides links to the relevant resources.
+{% endalert %}
+
+{% alert warning %}
+Arduino does NOT support the ARM based boards in the Marlin 2.0 codebase.
 {% endalert %}
 
 ## Configure Marlin
@@ -46,7 +51,7 @@ To configure Marlin you'll use the Arduino IDE (or your [favorite text editor](h
   (Marlin checks for several common errors)
 - Once all errors are fixed, proceed with the upload by clicking on the `Upload` button.
 
-## Flash your board
+## Flash (Upload) your board
 
 - Make sure `Marlin.ino` is open in the Arduino IDE. Continuing in the IDE...
 - Select your board/micro-controller from the `Tools` > `Boards` menu.

--- a/_basics/install_Arduino.md
+++ b/_basics/install_Arduino.md
@@ -1,6 +1,6 @@
 ---
-title:        Installing Marlin using Arduino
-description:  Marlin Installation Quick Start Guide
+title:        Installing Marlin (Arduino)
+description:  Marlin Install Quick Start Guide
 
 author: jbrazio
 contrib: thinkyhead
@@ -51,7 +51,7 @@ To configure Marlin you'll use the Arduino IDE (or your [favorite text editor](h
   (Marlin checks for several common errors)
 - Once all errors are fixed, proceed with the upload by clicking on the `Upload` button.
 
-## Flash (Upload) your board
+## Upload to the board
 
 - Make sure `Marlin.ino` is open in the Arduino IDE. Continuing in the IDE...
 - Select your board/micro-controller from the `Tools` > `Boards` menu.

--- a/_basics/install_PlatformIO.md
+++ b/_basics/install_PlatformIO.md
@@ -7,8 +7,6 @@ contrib: thinkyhead, Bob-the-Kuhn
 category: [ articles, getting-started ]
 ---
 
-
-
 To install Marlin on your printer you'll need to Download, Configure, [Compile](https://en.wikipedia.org/wiki/Compiler), and finally [Flash](https://www.arduino.cc/en/Guide/Environment#toc9) the compiled binary to your board. This process may seem a bit daunting at first, but once you've done it a few times it becomes second-nature.
 
 {% alert info %}
@@ -36,7 +34,7 @@ If the latest Marlin 1.1 requires too much Program Memory or SRAM to run on your
 {% alert warning %}
 The Marlin 1.0.x codebase does NOT support PlatformIO.
 
-The Marlin 1.1 releases all have PlatformIO support.  Marlin release 1.1.9 is the first that supports the two or three click build process detailed in this page.  Prior to 1.1.9 the user needs to scroll through a long list looking for the desired combination.
+The Marlin 1.1 releases all have PlatformIO support. Marlin release 1.1.9 is the first that supports the two or three click build process detailed in this page. Prior to 1.1.9 the user needs to scroll through a long list looking for the desired combination.
 {% endalert %}
 
 ## Configure Marlin
@@ -48,9 +46,9 @@ To configure Marlin you'll use your favorite text editor ([Atom](https://atom.io
 - Open the top level Marlin directory in PlatformIO.
 - Click on the "**Auto Build**" menu at the right end of the menus in the main menu bar to bring up the dialog.
 - A sub menu will pop up. Click on the "**PIO Build**" option.
-- If further info is needed then a popup will appear with check boxes listing the available options.  Select the option and then click on "**CONFIRM**".
+- If further info is needed then a popup will appear with check boxes listing the available options. Select the option and then click on "**CONFIRM**".
 - The build window will open and Marlin will be compiled. This may take several minutes to complete.
-- Check in the build window that PlatformIO reports SUCCESS.  If it reports ERROR then then the error(s) must be fixed before proceeding.
+- Check in the build window that PlatformIO reports SUCCESS. If it reports ERROR then then the error(s) must be fixed before proceeding.
 - Once all errors are fixed, proceed with flashing/uploading.
 
 ## Flash (Upload) your board
@@ -59,19 +57,17 @@ To configure Marlin you'll use your favorite text editor ([Atom](https://atom.io
 - Open the top level Marlin directory in PlatformIO.
 - Click on the "**Auto Build**" menu at the right end of the menus in the main menu bar to bring up the dialog.
 - A sub menu will pop up. Click on the "**PIO Upload**" option.
-- If further info is needed then a popup will appear with check boxes listing the available options.  Select the option and then click on "**CONFIRM**".
+- If further info is needed then a popup will appear with check boxes listing the available options. Select the option and then click on "**CONFIRM**".
 - The build window will open and Marlin will be compiled and the upload will be started automatically. This may take several minutes to complete.
 - A blue or green or yellow LED on the board will rapidly flash when the upload is in process.
 
 That’s it! Now that you’ve flashed Marlin to your board, enjoy silky smooth printing!
 
-
-
 # **`Details`**
 
 **Two or three mouse clicks** are all that is needed to build and upload Marlin to your board with this method.
 
-This method uses PlatformIO to do the build and upload.  Atom, process-palette and some custom programming automate the process.
+This method uses PlatformIO to do the build and upload. Atom, process-palette and some custom programming automate the process.
 
 There are multiple ways of customizing Marlin for your application. This method does not require or preclude any of them.
 
@@ -86,20 +82,19 @@ The PlatformIO IDE is distributed as a plugin for Google's ***Atom*** . This edi
 1. Install **Atom** and **PlatformIO** per this [**LINK**](http://docs.platformio.org/en/latest/ide/atom.html#installation)
 2. Repeat steps 2 and 3 in the above to install the **process-palette** package in Atom.
 
-_Pro Tip: PlatformIO is also available for 10+ other environments plus as a stand alone CLI tool.  Microsoft's **Visual Studio Code** (aka ***VSCode***) and ***Sublime*** are two of the more popular alternatives in the 3D printer community._
+_Pro Tip: PlatformIO is also available for 10+ other environments plus as a stand alone CLI tool. Microsoft's **Visual Studio Code** (aka ***VSCode***) and ***Sublime*** are two of the more popular alternatives in the 3D printer community._
 
 # Initial system and Marlin check
 
-This section creates an absolutely minimum Marlin configuration and uploads it to your board.  
+This section creates an absolutely minimum Marlin configuration and uploads it to your board.
 
-The intent is to verify that the build/compile/upload process works after the **Setup** step above is completed.  
+The intent is to verify that the build/compile/upload process works after the **Setup** step above is completed.
 
-Doing this minimal Marlin build can be skipped.  We recommend doing the minimal build because configuration errors could mask tool chain problems.
-
+Doing this minimal Marlin build can be skipped. We recommend doing the minimal build because configuration errors could mask tool chain problems.
 
 ## Download Marlin
 
-1. Download the flavor of Marlin that you want.  Click on one of the following links, then click on the "**Clone or download**" button and then click on the "**Download ZIP**" button.
+1. Download the flavor of Marlin that you want. Click on one of the following links, then click on the "**Clone or download**" button and then click on the "**Download ZIP**" button.
     - [Marlin 1.1](https://github.com/MarlinFirmware/Marlin/tree/1.1.x) -  latest released version of the 1.1 branch
     - [Marlin 1.1 "bugfix"](https://github.com/MarlinFirmware/Marlin/tree/bugfix-1.1.x) - very latest features and fixes - Cutting-edge code! Beware!
     - [Marlin 2.0 "bugfix"](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip) - includes support for ARM-based boards and expanded DUE functionality - Bleeding-edge code! Caution!
@@ -122,10 +117,9 @@ _Pro Tip: If you`re using **GitHub Desktop** to manage your own Marlin fork, sim
 
 4. In the file dialog, navigate to the **MarlinFirmware** folder you created earlier, highlight it, and click the "**Open**" button. The project folder and its contents should appear in the Project navigator on the left side.
 
-
 # Prepare minimal **Configuration.h**
 
-1. Open the **boards.h** file by clicking on it.  In 2.0 you'll need to navigate to a sub directory. From the project pane on the left, open the folders **Marlin** > **src** > **core**.
+1. Open the **boards.h** file by clicking on it. In 2.0 you'll need to navigate to a sub directory. From the project pane on the left, open the folders **Marlin** > **src** > **core**.
 
 2. Use the **Find** command or scroll down to locate the entry for your board. (e.g., **BOARD_AZTEEG_X5_GT**)
 
@@ -137,41 +131,37 @@ _Pro Tip: If you`re using **GitHub Desktop** to manage your own Marlin fork, sim
     #define MOTHERBOARD BOARD_AZTEEG_X5_GT
     ```
 
-4.  Save the file.
+4. Save the file.
 
 # Build Marlin
 
 1. Click on the **Auto Build**" menu at the right end of the menus in the main menu bar to bring up the dialog.
 
-2. A sub menu will pop up with the following choices.  Click on the "**PIO Build**" option.
+2. A sub menu will pop up with the following choices. Click on the "**PIO Build**" option.
 
 
-3. If further info is needed then a popup will appear with check boxes listing the available options.  Select the option and then click on "**CONFIRM**".
+3. If further info is needed then a popup will appear with check boxes listing the available options. Select the option and then click on "**CONFIRM**".
 
-4. The build window will open and Marlin will be compiled. This may take several minutes to complete.  
+4. The build window will open and Marlin will be compiled. This may take several minutes to complete.
 
-Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window.  If **ERROR** is seen then trouble shooting is required.
+Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window. If **ERROR** is seen then trouble shooting is required.
 
 
 # Upload Marlin
 
 Repeat the steps in **Build Marlin** but, in step 2, click on "**PIO Upload**" instead of "**PIO Build**"
 
-Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window.  If **ERROR** is seen then trouble shooting is required.
+Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window. If **ERROR** is seen then trouble shooting is required.
 
 ## Test the install
 
 You should now be able to communicate with Marlin and send commands using your favorite host software such as ***Simplify3D***, ***OctoPrint***, ***Pronterface*** or ***Repetier Host***.
 
-
-
-
-
 # Custom configuration
 
 For the first test build you should have used the default **Configuration.h** and **Configuration_adv.h** files. Now it's time to test your own configurations.
 
-If one exists for your board, we **`strongly`** suggest rebuilding your configs using one of the example configs located in the **Marlin/src/config/examples** folder as a starting-point.  This is done by copying (replacing) the example file(s) into the upper folder that has **Configuration.h** and **Configuration_adv.h** in it.  
+If one exists for your board, we **`strongly`** suggest rebuilding your configs using one of the example configs located in the **Marlin/src/config/examples** folder as a starting-point. This is done by copying (replacing) the example file(s) into the upper folder that has **Configuration.h** and **Configuration_adv.h** in it.
 
 You can use your favorite editor to modify the files.
 
@@ -180,29 +170,29 @@ You can use your favorite editor to modify the files.
 ## Auto Build submenu options
 
 
-The Auto Build submenu items exactly implement their PlatformIO counterparts.  See the PlatformIO documentation if further information is needed.
+The Auto Build submenu items exactly implement their PlatformIO counterparts. See the PlatformIO documentation if further information is needed.
 
-**PIO Upload (traceback)** is the only item that does not have a direct counterpart in PlatformIO.  See below for details.
+**PIO Upload (traceback)** is the only item that does not have a direct counterpart in PlatformIO. See below for details.
 
 #### PIO Build
 
-Compiles and builds the project.  An upload image will be created if there are no errors.
+Compiles and builds the project. An upload image will be created if there are no errors.
 
 #### PIO Clean
 
- Removes all files created by previous compilations and re-initializes the project state.  
+ Removes all files created by previous compilations and re-initializes the project state.
 
 #### PIO Upload
 
- Same as **PIO Build** but will attempt to upload the image if one was created.  The upload will be done via the **Upload port** specified in the **platformio.ini** file.
+Same as **PIO Build** but will attempt to upload the image if one was created. The upload will be done via the **Upload port** specified in the **platformio.ini** file.
 
- Usually an Upload Port is not specified.  In this case, depending on the board selected, either the first serial port found will be used or the image will be put into a disk file on the SD card in the board.
+Since the Upload Port is usually unspecified, depending on the board selected, PIO will either use the first serial port found or it will save the binary image file on the SD card in the board's SD slot.
 
 #### PIO Upload (traceback)
 
 Same as **PIO Upload** but includes debug info within the image.
 
-This option creates a special image useful when debugging certain types of firmware problems.  It is only available on ARM based boards.  Not all ARM CPUs/environments have implemented this.
+This option creates a special image useful when debugging certain types of firmware problems. It is only available on ARM based boards. Not all ARM CPUs/environments have implemented this.
 
 #### PIO Upload using Programmer
 
@@ -220,10 +210,9 @@ See PlatformIO documentation on how to use the **Debug** feature
 
 See PlatformIO documentation on how to use the **Remote** feature
 
-
 ## SD cards bigger than 32G
 
-SD cards bigger than 32G must be partitioned so that the first partition is 32G or less.  Marlin will only use the first partition.
+SD cards bigger than 32G must be partitioned so that the first partition is 32G or less. Marlin will only use the first partition.
 
 ## Hidden directories in the project folder
 
@@ -231,7 +220,7 @@ These can only be seen if you set your OS (Windows, OSX, Linux) option(s) to mak
 
 ### .pioenvs
 
-This directory is located in the top level project directory.  It contains the image created by the **build** and **upload** functions.
+This directory is located in the top level project directory. It contains the image created by the **build** and **upload** functions.
 
 ### .piolibdeps
 
@@ -247,7 +236,7 @@ It **`MUST`** be deleted when switching between 1.1 Marlin and 2.0 Marlin.
 
 The **pins_YOUR_BOARD.h** file is the only other file besides **Configuration.h** and **Configuration_adv.h** that is expected to be modified by the user.
 
-These are normally only modified if hardware is added that isn't already supported.  Most of the time this need results from such things as:
+These are normally only modified if hardware is added that isn't already supported. Most of the time this need results from such things as:
   - Using an LCD that is supported by Marlin but not by this file
   - Adding a Z probe that doesn't use the Z_MIN endstop
 
@@ -255,30 +244,25 @@ These are normally only modified if hardware is added that isn't already support
 
 If you're not comfortable modifying this file then [Post a New Issue](https://github.com/MarlinFirmware/Marlin/issues/new) and someone will be glad to help.
 
-
 ## LPC1768 & LPC1769 based boards
 
-These boards do not use a serial port to upload a new image.  Instead the new image is placed on the card's on-board SD card and the power is recycled.  When doing a power up the card checks for the existence of the file **firmware.bin**.  If one is found then the new image is copied to FLASH and the file is renamed to **FIRMWARE.CUR**. If there was a previous **FIRMWARE.CUR** then it is replaced by the new one.
+These boards do not use a serial port to upload a new image. Instead the new image is placed on the card's on-board SD card and the power is recycled. When doing a power up the card checks for the existence of the file **firmware.bin**. If one is found then the new image is copied to FLASH and the file is renamed to **FIRMWARE.CUR**. If there was a previous **FIRMWARE.CUR** then it is replaced by the new one.
 
 The on-board SD card is made available to the outside world via a USB virtual disk.
 
 Naming the (first) volume on the SD card **REARM** is recommended. That way a new (or re-formatted) SD card can be automatically targeted by the upload process.
 
-If the virtual disk isn't available then the upload will fail.  Just repeat the upload once the virtual disk appears.
+If the virtual disk isn't available then the upload will fail. Just repeat the upload once the virtual disk appears.
 
-Marlin contains a utility that will search the disks on the computer and copy **firmware.bin** from **.pioenvs** to the USB virtual disk.  The utility assumes the first disk that has **FIRMWARE.CUR** on it is the correct target.  If **FIRMWARE.CUR** isn't found then it sets the target to the first disk named **REARM**.
+Marlin contains a utility that will search the disks on the computer and copy **firmware.bin** from **.pioenvs** to the USB virtual disk. The utility assumes the first disk that has **FIRMWARE.CUR** on it is the correct target. If **FIRMWARE.CUR** isn't found then it sets the target to the first disk named **REARM**.
 
 If the utility fails then the upload will fail and the user will need to manually copy **firmware.bin** from **.pioenvs** to the correct disk.
 
+## Converting Configurations from 1.1 to 2.0
 
+There's no nice/easy way of switching from 1.1 to 2.0. It's a manual process of comparing the 1.1 **Configuration.h** and **Configuration_adv.h** files to their 2.0 counterparts.
 
-
-## Porting 1.1 configurations to 2.0
-
-
-There's no nice/easy way of switching from 1.1 to 2.0.  It's a manual process of comparing the 1.1 **Configuration.h** and **Configuration_adv.h** files to the 2.0 counterparts.
-
-A good side by side file compare utility will greatly aid in making the file changes.  The File Compare feature of ***Atom***, Compare plugin in ***Notepad++*** and ***Sublime*** (among others) are useful.
+A good side by side file compare utility will greatly aid in making the file changes. The File Compare feature of ***Atom***, Compare plugin in ***Notepad++*** and ***Sublime*** (among others) are useful.
 
 Complicating things are different names for the same feature/function/option, new or not yet supported features and moved items.
 

--- a/_basics/install_PlatformIO.md
+++ b/_basics/install_PlatformIO.md
@@ -1,0 +1,285 @@
+---
+title:        Installing Marlin using PlatformIO
+description:  Marlin Installation Quick Start Guide
+
+author: ModMike
+contrib: thinkyhead, Bob-the-Kuhn
+category: [ articles, getting-started ]
+---
+
+
+
+To install Marlin on your printer you'll need to Download, Configure, [Compile](https://en.wikipedia.org/wiki/Compiler), and finally [Flash](https://www.arduino.cc/en/Guide/Environment#toc9) the compiled binary to your board. This process may seem a bit daunting at first, but once you've done it a few times it becomes second-nature.
+
+{% alert info %}
+Marlin only needs to be re-flashed when options are changed in the configuration files. Several settings can be changed and saved to EEPROM while the printer is running.
+{% endalert %}
+
+## Download the PlatformIO IDE
+
+Installation of PlatformIO is covered in the Details section. Marlin can be compiled on Linux, Windows, macOS, and Unix.
+
+## Download Marlin Source Code
+
+When choosing a version of Marlin to install, there are a few different [codebases](https://en.wikipedia.org/wiki/Codebase) to choose from:
+
+Link|Description
+----|-----------
+[Download 1.1.x](https://github.com/MarlinFirmware/Marlin/archive/1.1.x.zip)|The current release version
+[Download 1.0.x](https://github.com/MarlinFirmware/Marlin/archive/1.0.x.zip)|The previous release version
+[Download bugfix-1.1.x](https://github.com/MarlinFirmware/Marlin/archive/bugfix-1.1.x.zip)|The "nightly" build version — Cutting-edge code! Beware!
+[Download bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip)|The "nightly" build version - Bleeding-edge code! Caution!
+
+If the latest Marlin 1.1 requires too much Program Memory or SRAM to run on your legacy board, first try disabling some features to reclaim space. Next, try the 2.0 codebase.
+
+
+{% alert warning %}
+The Marlin 1.0.x codebase does NOT support PlatformIO.
+
+The Marlin 1.1 releases all have PlatformIO support.  Marlin release 1.1.9 is the first that supports the two or three click build process detailed in this page.  Prior to 1.1.9 the user needs to scroll through a long list looking for the desired combination.
+{% endalert %}
+
+## Configure Marlin
+
+To configure Marlin you'll use your favorite text editor ([Atom](https://atom.io/), [Sublime](https://www.sublimetext.com/), [Notepad++](https://notepad-plus-plus.org/), ...) to edit two text files: `Configuration.h` and `Configuration_adv.h`. See [Configuring Marlin](/docs/configuration/configuration.html) for an explanation of the configuration file format and a synopsis of most of options in these files. The configuration files themselves also contain very thorough documentation for every option. We recommend you read both for to better know your RepRap or clone.
+
+## Verify/Compile
+
+- Open the top level Marlin directory in PlatformIO.
+- Click on the "**Auto Build**" menu at the right end of the menus in the main menu bar to bring up the dialog.
+- A sub menu will pop up. Click on the "**PIO Build**" option.
+- If further info is needed then a popup will appear with check boxes listing the available options.  Select the option and then click on "**CONFIRM**".
+- The build window will open and Marlin will be compiled. This may take several minutes to complete.
+- Check in the build window that PlatformIO reports SUCCESS.  If it reports ERROR then then the error(s) must be fixed before proceeding.
+- Once all errors are fixed, proceed with flashing/uploading.
+
+## Flash (Upload) your board
+
+- A few boards require setting "program mode" before they can be flashed/uploaded, but most do not.
+- Open the top level Marlin directory in PlatformIO.
+- Click on the "**Auto Build**" menu at the right end of the menus in the main menu bar to bring up the dialog.
+- A sub menu will pop up. Click on the "**PIO Upload**" option.
+- If further info is needed then a popup will appear with check boxes listing the available options.  Select the option and then click on "**CONFIRM**".
+- The build window will open and Marlin will be compiled and the upload will be started automatically. This may take several minutes to complete.
+- A blue or green or yellow LED on the board will rapidly flash when the upload is in process.
+
+That’s it! Now that you’ve flashed Marlin to your board, enjoy silky smooth printing!
+
+
+
+# **`Details`**
+
+**Two or three mouse clicks** are all that is needed to build and upload Marlin to your board with this method.
+
+This method uses PlatformIO to do the build and upload.  Atom, process-palette and some custom programming automate the process.
+
+There are multiple ways of customizing Marlin for your application. This method does not require or preclude any of them.
+
+A sample customization process is given as a means of showing how this method could be used by someone new to Marlin or new to PlatformIO.
+
+# Install PlatformIO
+
+This step is only done once.
+
+The PlatformIO IDE is distributed as a plugin for Google's ***Atom*** . This editor has a robust plugin architecture that allows it to become full-featured integrated development environment (IDE) for PlatformIO.
+
+1. Install **Atom** and **PlatformIO** per this [**LINK**](http://docs.platformio.org/en/latest/ide/atom.html#installation)
+2. Repeat steps 2 and 3 in the above to install the **process-palette** package in Atom.
+
+_Pro Tip: PlatformIO is also available for 10+ other environments plus as a stand alone CLI tool.  Microsoft's **Visual Studio Code** (aka ***VSCode***) and ***Sublime*** are two of the more popular alternatives in the 3D printer community._
+
+# Initial system and Marlin check
+
+This section creates an absolutely minimum Marlin configuration and uploads it to your board.  
+
+The intent is to verify that the build/compile/upload process works after the **Setup** step above is completed.  
+
+Doing this minimal Marlin build can be skipped.  We recommend doing the minimal build because configuration errors could mask tool chain problems.
+
+
+## Download Marlin
+
+1. Download the flavor of Marlin that you want.  Click on one of the following links, then click on the "**Clone or download**" button and then click on the "**Download ZIP**" button.
+    - [Marlin 1.1](https://github.com/MarlinFirmware/Marlin/tree/1.1.x) -  latest released version of the 1.1 branch
+    - [Marlin 1.1 "bugfix"](https://github.com/MarlinFirmware/Marlin/tree/bugfix-1.1.x) - very latest features and fixes - Cutting-edge code! Beware!
+    - [Marlin 2.0 "bugfix"](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip) - includes support for ARM-based boards and expanded DUE functionality - Bleeding-edge code! Caution!
+    - [Marlin 1.0]() - "**doesn't support PlatformIO**"
+
+
+2. Move the **ZIP** file to your "**Documents**" folder (or wherever you prefer) and expand the ZIP archive as you usually do.
+
+3. Rename the folder to "**MarlinFirmware**" so we're all on the same page here.
+
+_Pro Tip: If you`re using **GitHub Desktop** to manage your own Marlin fork, simply activate the desired branch._
+
+## Open Marlin in PlatformIO IDE
+
+1. At this point you may already have the project editor running. If not, go ahead and launch ***Atom***.
+
+2. The "**PlatformIO Home**" page should appear. If not, click on the **Home** icon located in the top-left corner.
+
+3. Click the "**Open Project**" button under "**Quick Access**."
+
+4. In the file dialog, navigate to the **MarlinFirmware** folder you created earlier, highlight it, and click the "**Open**" button. The project folder and its contents should appear in the Project navigator on the left side.
+
+
+# Prepare minimal **Configuration.h**
+
+1. Open the **boards.h** file by clicking on it.  In 2.0 you'll need to navigate to a sub directory. From the project pane on the left, open the folders **Marlin** > **src** > **core**.
+
+2. Use the **Find** command or scroll down to locate the entry for your board. (e.g., **BOARD_AZTEEG_X5_GT**)
+
+3. Open the **Configuration.h** file by clicking on it.
+
+4. As above, set **MOTHERBOARD** to the name of your board.
+
+    ```
+    #define MOTHERBOARD BOARD_AZTEEG_X5_GT
+    ```
+
+4.  Save the file.
+
+# Build Marlin
+
+1. Click on the **Auto Build**" menu at the right end of the menus in the main menu bar to bring up the dialog.
+
+2. A sub menu will pop up with the following choices.  Click on the "**PIO Build**" option.
+
+
+3. If further info is needed then a popup will appear with check boxes listing the available options.  Select the option and then click on "**CONFIRM**".
+
+4. The build window will open and Marlin will be compiled. This may take several minutes to complete.  
+
+Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window.  If **ERROR** is seen then trouble shooting is required.
+
+
+# Upload Marlin
+
+Repeat the steps in **Build Marlin** but, in step 2, click on "**PIO Upload**" instead of "**PIO Build**"
+
+Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window.  If **ERROR** is seen then trouble shooting is required.
+
+## Test the install
+
+You should now be able to communicate with Marlin and send commands using your favorite host software such as ***Simplify3D***, ***OctoPrint***, ***Pronterface*** or ***Repetier Host***.
+
+
+
+
+
+# Custom configuration
+
+For the first test build you should have used the default **Configuration.h** and **Configuration_adv.h** files. Now it's time to test your own configurations.
+
+If one exists for your board, we **`strongly`** suggest rebuilding your configs using one of the example configs located in the **Marlin/src/config/examples** folder as a starting-point.  This is done by copying (replacing) the example file(s) into the upper folder that has **Configuration.h** and **Configuration_adv.h** in it.  
+
+You can use your favorite editor to modify the files.
+
+# Advanced topics
+
+## Auto Build submenu options
+
+
+The Auto Build submenu items exactly implement their PlatformIO counterparts.  See the PlatformIO documentation if further information is needed.
+
+**PIO Upload (traceback)** is the only item that does not have a direct counterpart in PlatformIO.  See below for details.
+
+#### PIO Build
+
+Compiles and builds the project.  An upload image will be created if there are no errors.
+
+#### PIO Clean
+
+ Removes all files created by previous compilations and re-initializes the project state.  
+
+#### PIO Upload
+
+ Same as **PIO Build** but will attempt to upload the image if one was created.  The upload will be done via the **Upload port** specified in the **platformio.ini** file.
+
+ Usually an Upload Port is not specified.  In this case, depending on the board selected, either the first serial port found will be used or the image will be put into a disk file on the SD card in the board.
+
+#### PIO Upload (traceback)
+
+Same as **PIO Upload** but includes debug info within the image.
+
+This option creates a special image useful when debugging certain types of firmware problems.  It is only available on ARM based boards.  Not all ARM CPUs/environments have implemented this.
+
+#### PIO Upload using Programmer
+
+Same as **PIO Upload** but will use the programmer specified in the **platformio.ini** file.
+
+#### PIO Test
+
+See PlatformIO documentation on how to use the **Test** feature
+
+#### PIO Debug
+
+See PlatformIO documentation on how to use the **Debug** feature
+
+#### PIO Remote
+
+See PlatformIO documentation on how to use the **Remote** feature
+
+
+## SD cards bigger than 32G
+
+SD cards bigger than 32G must be partitioned so that the first partition is 32G or less.  Marlin will only use the first partition.
+
+## Hidden directories in the project folder
+
+These can only be seen if you set your OS (Windows, OSX, Linux) option(s) to make them visible.
+
+### .pioenvs
+
+This directory is located in the top level project directory.  It contains the image created by the **build** and **upload** functions.
+
+### .piolibdeps
+
+This directory contains the libraries used in the compile/build process.
+
+If not present it is rebuilt using the specifications in platformio.ini from the latest versions available.
+
+It should be deleted **`EVERY TIME`** Marlin is downloaded from **github**.
+
+It **`MUST`** be deleted when switching between 1.1 Marlin and 2.0 Marlin.
+
+## Modifying pins_YOUR_BOARD.h files
+
+The **pins_YOUR_BOARD.h** file is the only other file besides **Configuration.h** and **Configuration_adv.h** that is expected to be modified by the user.
+
+These are normally only modified if hardware is added that isn't already supported.  Most of the time this need results from such things as:
+  - Using an LCD that is supported by Marlin but not by this file
+  - Adding a Z probe that doesn't use the Z_MIN endstop
+
+**`In rare cases modifications have resulted in physical damage to the printer.`**
+
+If you're not comfortable modifying this file then [Post a New Issue](https://github.com/MarlinFirmware/Marlin/issues/new) and someone will be glad to help.
+
+
+## LPC1768 & LPC1769 based boards
+
+These boards do not use a serial port to upload a new image.  Instead the new image is placed on the card's on-board SD card and the power is recycled.  When doing a power up the card checks for the existence of the file **firmware.bin**.  If one is found then the new image is copied to FLASH and the file is renamed to **FIRMWARE.CUR**. If there was a previous **FIRMWARE.CUR** then it is replaced by the new one.
+
+The on-board SD card is made available to the outside world via a USB virtual disk.
+
+Naming the (first) volume on the SD card **REARM** is recommended. That way a new (or re-formatted) SD card can be automatically targeted by the upload process.
+
+If the virtual disk isn't available then the upload will fail.  Just repeat the upload once the virtual disk appears.
+
+Marlin contains a utility that will search the disks on the computer and copy **firmware.bin** from **.pioenvs** to the USB virtual disk.  The utility assumes the first disk that has **FIRMWARE.CUR** on it is the correct target.  If **FIRMWARE.CUR** isn't found then it sets the target to the first disk named **REARM**.
+
+If the utility fails then the upload will fail and the user will need to manually copy **firmware.bin** from **.pioenvs** to the correct disk.
+
+
+
+
+## Porting 1.1 configurations to 2.0
+
+
+There's no nice/easy way of switching from 1.1 to 2.0.  It's a manual process of comparing the 1.1 **Configuration.h** and **Configuration_adv.h** files to the 2.0 counterparts.
+
+A good side by side file compare utility will greatly aid in making the file changes.  The File Compare feature of ***Atom***, Compare plugin in ***Notepad++*** and ***Sublime*** (among others) are useful.
+
+Complicating things are different names for the same feature/function/option, new or not yet supported features and moved items.
+
+As before, start with the example configuration for your board if one is available in 2.0.

--- a/_basics/install_PlatformIO.md
+++ b/_basics/install_PlatformIO.md
@@ -30,7 +30,6 @@ Link|Description
 
 If the latest Marlin 1.1 requires too much Program Memory or SRAM to run on your legacy board, first try disabling some features to reclaim space. Next, try the 2.0 codebase.
 
-
 {% alert warning %}
 The Marlin 1.0.x codebase does NOT support PlatformIO.
 
@@ -100,7 +99,6 @@ Doing this minimal Marlin build can be skipped. We recommend doing the minimal b
     - [Marlin 2.0 "bugfix"](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip) - includes support for ARM-based boards and expanded DUE functionality - Bleeding-edge code! Caution!
     - [Marlin 1.0]() - "**doesn't support PlatformIO**"
 
-
 2. Move the **ZIP** file to your "**Documents**" folder (or wherever you prefer) and expand the ZIP archive as you usually do.
 
 3. Rename the folder to "**MarlinFirmware**" so we're all on the same page here.
@@ -146,7 +144,6 @@ _Pro Tip: If you`re using **GitHub Desktop** to manage your own Marlin fork, sim
 
 Do NOT proceed to the next step unless **SUCCESS** is seen near the bottom of the build window. If **ERROR** is seen then trouble shooting is required.
 
-
 # Upload Marlin
 
 Repeat the steps in **Build Marlin** but, in step 2, click on "**PIO Upload**" instead of "**PIO Build**"
@@ -169,7 +166,6 @@ You can use your favorite editor to modify the files.
 
 ## Auto Build submenu options
 
-
 The Auto Build submenu items exactly implement their PlatformIO counterparts. See the PlatformIO documentation if further information is needed.
 
 **PIO Upload (traceback)** is the only item that does not have a direct counterpart in PlatformIO. See below for details.
@@ -180,7 +176,7 @@ Compiles and builds the project. An upload image will be created if there are no
 
 #### PIO Clean
 
- Removes all files created by previous compilations and re-initializes the project state.
+Removes all files created by previous compilations and re-initializes the project state.
 
 #### PIO Upload
 

--- a/_basics/install_PlatformIO.md
+++ b/_basics/install_PlatformIO.md
@@ -1,5 +1,5 @@
 ---
-title:        Installing Marlin using PlatformIO
+title:        Installing Marlin (PlatformIO)
 description:  Marlin Installation Quick Start Guide
 
 author: ModMike

--- a/_board_specific_startup/Re_ARM.md
+++ b/_board_specific_startup/Re_ARM.md
@@ -1,5 +1,5 @@
 ---
-title:        Bringing up Re-ARM
+title:        Installing Marlin on Re-ARM
 description:  Re-ARM specific hardware and software setup
 
 author: ModMike
@@ -45,7 +45,6 @@ See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
 
 This method is recommended because it is relatively easy and closely parallels this document.
 
-
 ## Download Marlin 2.0
 
 1. Download the [Marlin 2.0 "bugfix" version](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip) which includes support for ARM-based boards.
@@ -65,7 +64,6 @@ _Pro Tip: If you're using **GitHub Desktop** to manage your own Marlin fork, sim
 3. Click the "**Open Project**" button under "**Quick Access**."
 
 4. In the file dialog, navigate to the `MarlinFirmware` folder you created earlier, highlight it, and click the "**Open**" button. The project folder and its contents should appear in the Project navigator on the left side.
-
 
 # Prepare `Configuration.h`
 
@@ -168,7 +166,6 @@ _Tip:  When doing consecutive builds, it's always good practice to check the dat
 For the first test build you should have used the default `Configuration.h` and `Configuration_adv.h` files. Now it's time to test your own configurations.
 
 We strongly suggest rebuilding your configs using one of the included example configs located in the **Marlin/src/config/examples** folder as a starting-point by first copying the appropriate files into the `MarlinFirmware/Marlin` folder. For much of this process, you can use the File Compare feature of ***Atom*** or ***VSCode***. Note that this won't help with any renamed or moved items.
-
 
 # The main event!
 

--- a/_board_specific_startup/Re_ARM.md
+++ b/_board_specific_startup/Re_ARM.md
@@ -1,0 +1,191 @@
+---
+title:        Bringing up Re-ARM
+description:  Re-ARM specific hardware and software setup
+
+author: ModMike
+contrib: thinkyhead, Bob-the-Kuhn
+category: [ board-specific ]
+---
+
+This page describes the process of installing Marlin 2.x onto the Re-Arm (LPC1768-based) board.
+
+While this procedure specifically targets the Re-Arm board, it can apply to any Marlin HAL-compatible controller with an onboard bootable SD card. (Notes for "other boards" are included where needed.) These instructions are OS-agnostic. The term "File Browser" refers to both the macOS Finder and Windows Explorer.
+
+To increase your chances of success, start out with the default Marlin configuration files. Except as directed, don't modify `Configuration.h` or `Configuration_adv.h` until you've achieved a successful build, upload, and test using the base configuration.
+
+# Prepare
+
+## Before you begin
+
+***DO NOT attach your RAMPS Board yet!*** If the RAMPS is currently installed on the Re-Arm board, we recommend you remove it before proceeding. Once you've validated the installation and made sure everything works then the RAMPS can be attached for [the main event](#the-main-event)!
+
+## Format an SD Card for Re-Arm
+
+**Follow this procedure exactly!** An improperly-formatted card may seem to be working but the board will not be able to write the required `FIRMWARE.CUR` file. This can (and does) cause a lot of frustration.
+
+On 32-bit boards the onboard SD card is used to store to the board's operating system (in this case, Marlin Firmware) and data. It cannot be used to store G-code for printing. For SD card printing you must use a separate SD card reader in a dedicated unit, such as an LCD controller.
+
+**Important:**  If your SD card is larger than 32GB, _it must be partitioned_ so that the first partion is no larger than 32GB. The other partitions don't matter. Please refer to your system's tools or do a web search for "partition SD card."
+
+1. Format a 32GB SD card as FAT32 and name it "`REARM`".
+
+2. Insert the card into the Re-Arm's onboard SD card slot.
+
+3. Locate the red jumper on the Re-Arm board next to the reset switch. Move the jumper to the 'USB' (right) position so the board will be powered from the USB port.
+
+4. Connect the board to the computer using a USB cable.
+
+If all is well an SD card volume named "`REARM`" will appear on your Desktop (and/or the file browser).
+
+*If you've given the card a different name or if it uses a different system, you will need to know the exact logical path to the drive. Don't worry about this for now. It will be described in the **[Build Marlin](#build-marlin)** section below.*
+
+## Install PlatformIO
+
+See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
+
+This method is recommended because it is relatively easy and closely parallels this document.
+
+
+## Download Marlin 2.0
+
+1. Download the [Marlin 2.0 "bugfix" version](https://github.com/MarlinFirmware/Marlin/archive/bugfix-2.0.x.zip) which includes support for ARM-based boards.
+
+2. Move the `bugfix-2.0.x.zip` file to your "Documents" folder (or wherever you prefer) and expand the ZIP archive as you usually do.
+
+3. Rename the folder to "`MarlinFirmware`" so we're all on the same page here.
+
+_Pro Tip: If you're using **GitHub Desktop** to manage your own Marlin fork, simply activate the `bugfix-2.0.x` branch._
+
+## Open Marlin in PlatformIO IDE
+
+1. At this point you may already have the project editor running. If not, go ahead and launch ***Atom***.
+
+2. The "**PlatformIO Home**" page should appear. If not, click on the **Home** icon located in the top-left corner.
+
+3. Click the "**Open Project**" button under "**Quick Access**."
+
+4. In the file dialog, navigate to the `MarlinFirmware` folder you created earlier, highlight it, and click the "**Open**" button. The project folder and its contents should appear in the Project navigator on the left side.
+
+
+# Prepare `Configuration.h`
+
+1. Close the **Platform IO Home** (or **PIO Home**) tab.
+
+2. From the project pane on the left, locate the **Marlin** folder and click on it to disclose its contents. Click on `Configuration.h` to open it in a new tab.
+
+3. Find the `MOTHERBOARD` setting and change it to the following for Re-ARM:
+
+    ```
+    #define MOTHERBOARD BOARD_RAMPS_14_RE_ARM_EFB
+    ```
+
+4. Save the file.
+
+The "EFB" acronym in the board name refers to _Extruder_, _Fan_, and _Bed_. This defines the order that these components should be connected to the `D10`, `D9`, and `D8` power outputs on the board. (EFB is the most common layout.)
+
+## For other boards…
+
+1. From the project pane on the left, open the folders `Marlin` > `src` > `core` and click on the `boards.h` file.
+
+2. Use the **Find** command or scroll down to locate the entry for your board. (e.g., `BOARD_AZTEEG_X5_GT`)
+
+3. As above, set `MOTHERBOARD` to the name of your board.
+
+    ```
+    #define MOTHERBOARD BOARD_AZTEEG_X5_GT
+    ```
+
+4.  Save the file.
+
+# Build Marlin
+
+## Method 1 - Preferred
+
+See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
+
+## Method 2
+
+1. Click on **PIO Build** in the bottom left to bring up the dialog.
+
+2. Scroll down and select "**PIO Build (LPC1768)**". (You can also type out "LPC17...", use the arrow keys, and press return.)
+
+3. The build window will open and Marlin will be compiled. (This may take a minute or two.) If the build is successful, the window will close and the `firmware.bin` file will be saved in the `.pioenvs/LPC1768` folder.
+
+### For other boards…
+
+You probably guessed that you would have to scroll to and pick "PIO Build your env_name".
+
+# Upload Marlin
+
+Methods 1 and 2, after a successful run, will result in the `firmware.bin` file being in the `.pioenvs/LPC1768` folder ***and*** on the SD card on the Re-Arm board..
+
+If `firmware.bin` isn't on the SD card then either rerun the Method or use Method 3 to manually move the file onto the SD card.
+
+## Method 1 - Preferred
+
+See [Installing Marlin (PlatformIO)](/docs/basics/install_Atom_PlatformIO.html)
+
+## Method 2
+
+1. Click on **PIO Build** in the bottom left to bring up the dialog.
+
+2. Scroll down and select "**PIO Upload (LPC1768)**". (You can also type out "LPC17...", use the arrow keys, and press return.)
+
+3. Wait while Marlin is compiled and uploaded. (This may take a few minutes.)
+
+## Method 3
+
+If there is a properly formatted SD card in your Re-Arm board and the board is powered on, you should see it on the desktop and in the file browser. You don't need to remove the card from the Re-Arm and insert it into your computer, although that works too.
+
+Note that this method requires accessing a hidden directory containing the `firmware.bin` file. Both Windows Explorer and the macOS Finder have a "Go to folder…" command that can be used to open hidden folders, and that's how we'll do this part.
+
+1. Using Windows Explorer or macOS Finder, navigate to your `MarlinFirmware`folder. All the visible files and folders, such as `Marlin` and `frameworks` will be shown.
+    - For Windows use Ctrl-D to select the address bar and add `/.pioenvs` to the end of the path. Press Return to open the hidden folder.
+    - On macOS select **Go to Folder…** from the **Go** menu. Type `.pioenvs` and press Return to open the hidden folder.
+
+2. Open the `LPC1768` folder.
+
+3. Copy the `firmware.bin` file to the "`rearm`" SD card.
+
+# Finalize
+
+1. Push the reset button on the Re-Arm board to register your new build.
+
+2. Wait until the SD card named "`REARM`" reappears on your desktop and use the file browser to open the card and verify that the `FIRMWARE.CUR` file was created.
+
+If you don't see this file, you'll need to do a hard reset by unplugging the USB cable, counting to 10, and plugging the USB cable back in.
+
+If you see the file but still have issues, simply delete the file, empty the Recycle Bin (or Trash) and power-cycle the controller.
+
+## Test the install
+
+You should now be able to communicate with Marlin and send commands using your favorite host software such as ***Simplify3D***, ***OctoPrint***, ***Pronterface***, ***Repetier Host***, or the ***Arduino*** serial monitor.
+
+_Tip:  When doing consecutive builds, it's always good practice to check the date and time of the files to make sure the Re-Arm processed them._
+
+# Custom configuration
+
+For the first test build you should have used the default `Configuration.h` and `Configuration_adv.h` files. Now it's time to test your own configurations.
+
+We strongly suggest rebuilding your configs using one of the included example configs located in the **Marlin/src/config/examples** folder as a starting-point by first copying the appropriate files into the `MarlinFirmware/Marlin` folder. For much of this process, you can use the File Compare feature of ***Atom*** or ***VSCode***. Note that this won't help with any renamed or moved items.
+
+
+# The main event!
+
+All of Re-Arm's logic pins are 3.3V, but all pins (except analog!) are 5V tolerant, so there's no reason to worry about voltage-divided induction sensor signal voltages or other 5V devices you may be using.
+
+1. Connect using your host terminal to check that the board is working. Start by sending an `M119` to get a report of the endstops, and try `M500` to initialize the `eprom.dat` file.
+
+2. Unplug the USB cable from the board.
+
+3. Locate the red jumper on the Re-Arm board, next to the reset switch. Move the jumper to the 'INT' (left) position so the board will be powered by the internal power.
+
+4. Assemble your RAMPS sandwich.
+
+5. Plug in USB.
+
+6. Connect a power source (12V up to 24V).
+
+*The Re-Arm board is meant to be 24V-capable, so if your RAMPS is up to it, you can boost the voltage for more torque and faster heating. There's no need to cut the diode or use a separate power supply (or so they say). We'll have more to report as we do more testing with this board!*
+
+# Good luck!

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -30,18 +30,23 @@
               Download Marlin
             </a></li>
 
-            <li><a href="{{ '/docs/basics/install.html' }}">
-              Installing Marlin (AVR)
+            <li><a href="{{ '/docs/basics/install_Arduino.html' }}">
+              Installing Marlin (Arduino)
             </a></li>
 
-            <li><a href="{{ '/docs/basics/install_arm.html' }}">
-              Installing Marlin (ARM)
+            <li><a href="{{ '/docs/basics/install_PlatformIO.html' }}">
+              Installing Marlin (PlatformIO)
             </a></li>
 
             <li><a href="{{ '/docs/configuration/configuration.html' }}">
               Configuring Marlin
             </a></li>
-
+            
+            <li class="divider"></li>
+            
+            <li><a href="{{ '/docs/basics/Re-ARM.html' }}">
+              Re-ARM initial bring up
+            </a></li>
             <li class="divider"></li>
 
             <li><a href="{{ '/docs/basics/reporting_bugs.html' }}">


### PR DESCRIPTION
This PR presents PlatformIO as a major alternative to Arduino for compiling & uploading Marlin.  It is based on the auto-build changes making PlatformIO easier to use than Arduino.

The biggest change is the addition of a general PlatformIO instruction page.  This page is a combination of the current Arduino getting started page, @ModMike 's LPC1768 page and new content.

The current Arduino getting started page was slightly modified.

The getting started menu was modified so that the Arduino and the new page have similar titles.

----

Major portions of Mike's  LPC1768 page were too specific to be included in a general document aimed at newer users.  There have been plenty of requests for board specific pages like Mikes so my idea was to add a submenu to the getting Started menu that held pages like Mike's.  

To that end I reworked Mike's page to include the auto-build option.

The stumbling block is that I have not been able to create a submenu under the getting started menu.  I was hoping to create something like Configuration under Documents.  

I was able to create a submenu but I wasn't able to put Mikes doc under it or give it a name.  It was just a slightly modified Documents menu.  I think the key for me to keep moving on this is to understand how to add members to the site.collection or to be able to create a collection specifically for the getting started menu.

Another problem i had was coming up with a title for the submenu.  I finally just started calling it Board Specific.  Hope someone comes up with  a better name..

I did create the directory **_board_specific** as a container for Mike's page.

For the time being I just put Mike's page as another entry on the Getting Started menu.  I know Scott will do his magic and make it all pretty.






The bad part is Mike's LPC1768 page