### PR TITLE
[LIN_ADVANCE] Changes on "Nozzle line ratio" tooltip

### DIFF
--- a/_tools/lin_advance/k-factor.html
+++ b/_tools/lin_advance/k-factor.html
@@ -217,7 +217,7 @@ category:     [ tools ]
           <tr>
             <td><label for="NOZ_LIN_R">Nozzle Line Ratio:</label></td>
             <td><input name="NOZ_LIN_R" type="number" id="NOZ_LIN_R" step="0.1" value="1.2"></td>
-            <td>Ratio between nozzle diameter and extruded line width. Should be between 1.05 and 1.2</td>
+            <td>Ratio between extruded line width and nozzle diameter. Should be between 1.05 and 1.2</td>
           </tr>
           <tr>
             <td><label for="OFFSET_Z">Z-Offset:</label></td>


### PR DESCRIPTION
@Sebastianv650 I'm not entirely sure but I believe that the ratio should be between extruded line width and nozzle diameter, not the other way around, and I think it makes sense since the ratio between the average nozzle diameter and the average extrusion width (1.2x times the nozzle dia) is 1.2, as said in the tooltip, but I may be wrong