### PR TITLE
Add details of FW-Retract implementation

### DIFF
--- a/_gcode/G010.md
+++ b/_gcode/G010.md
@@ -15,6 +15,8 @@ codes:
 long: 
   - Retract the filament according to settings of [`M207`](/docs/gcode/M207.html).
   - Firmware retraction allows you to tune retraction at the machine level and can significantly reduce the size of G-code files.
+  - Multiple consecutive `G10` or `G10 S1` commands without a corresponding `G11` or `G11 S1` will be ignored.
+  - Performs two moves: a retract move at the retract feedrate/acceleration, plus an optional Z lift at the maximum Z feedrate (travel acceleration).
 
 notes:
   - Requires `FWRETRACT`.

--- a/_gcode/G011.md
+++ b/_gcode/G011.md
@@ -12,7 +12,10 @@ group: planner
 codes:
   - G11
 
-long: Unretract (i.e., recover, prime) the filament according to settings of [`M208`](/docs/gcode/M208.html).
+long:
+  - Unretract (i.e., recover, prime) the filament according to settings of [`M208`](/docs/gcode/M208.html).
+  - Multiple consecutive `G11` or `G11 S1` commands without a corresponding `G10` or `G10 S1` will be ignored.
+  - Performs two moves: Lowers Z at the maximum Z feedrate (travel acceleration), plus an extruder-only recovery at the recover feedrate (retract acceleration).
 
 notes:
   - Requires `FWRETRACT`.


### PR DESCRIPTION
This clarifies that FW-Retract is performed as two separate moves, and that Z-hop uses the maximum Z feedrate (although I'm pretty sure its usually acceleration limited).