### PR TITLE
Update M106.md

### DIFF
--- a/_gcode/M106.md
+++ b/_gcode/M106.md
@@ -21,7 +21,7 @@ parameters:
   -
     tag: S
     optional: true
-    description: Speed
+    description: Speed (in percent)
     values:
       -
         tag: speed


### PR DESCRIPTION
Mentioned the fact that the fan speed is a percentage of total speed.  Before there was no mention to any unit of speed.