### PR TITLE
Fix G28 Z parameter description

### DIFF
--- a/_gcode/G028.md
+++ b/_gcode/G028.md
@@ -42,7 +42,7 @@ parameters:
     tag: Z
     type: boolean
     optional: true
-    description: A coordinate on the Z axis
+    description: Flag to go back to the Z axis origin
 
 examples:
   -


### PR DESCRIPTION
Fixed inappropriate description of `Z` parameter for `G28` command.