### PR TITLE
K-Factor: 1) Heat bed before homing 2) Load a stored mesh from EEPROM

### DIFF
--- a/tools/lin_advance/k-factor.html
+++ b/tools/lin_advance/k-factor.html
@@ -1,6 +1,111 @@
-<!DOCTYPE html> <html lang="en"> <head> <meta charset="utf-8"> <meta http-equiv="X-UA-Compatible" content="IE=edge"> <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> <meta name="viewport" content="width=device-width, initial-scale=1"> <title>Linear Advance Calibration Pattern | Marlin Firmware</title> <meta property="og:title" content="Linear Advance Calibration Pattern"> <meta name="author" content="MarlinFirmware"> <meta property="og:locale" content="en_US"> <meta name="description" content="Create Gcode to calibrate LIN_ADVANCE setting"> <meta property="og:description" content="Create Gcode to calibrate LIN_ADVANCE setting"> <link rel="canonical" href="http://marlinfw.org/tools/lin_advance/k-factor.html"> <meta property="og:url" content="http://marlinfw.org/tools/lin_advance/k-factor.html"> <meta property="og:site_name" content="Marlin Firmware"> <meta property="og:type" content="article"> <meta property="article:published_time" content="2018-10-31T03:43:26+00:00"> <meta name="twitter:card" content="summary"> <meta name="twitter:site" content="@MarlinFirmware"> <meta name="twitter:creator" content="@MarlinFirmware"> <script type="application/ld+json">
-{"@context":"http://schema.org","@type":"BlogPosting","headline":"Linear Advance Calibration Pattern","author":{"@type":"Person","name":"MarlinFirmware"},"datePublished":"2018-10-31T03:43:26+00:00","dateModified":"2018-10-31T03:43:26+00:00","description":"Create Gcode to calibrate LIN_ADVANCE setting","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"http://marlinfw.org/assets/images/logo/marlin/small.png"},"name":"MarlinFirmware"},"mainEntityOfPage":{"@type":"WebPage","@id":"http://marlinfw.org/tools/lin_advance/k-factor.html"},"url":"http://marlinfw.org/tools/lin_advance/k-factor.html"}</script> <link rel="icon" href="/assets/favicon.ico"> <link rel="stylesheet" href="/assets/stylesheets/main.css"> <!--[if lt IE 9]><script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script> <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script><![endif]--> <script src="/assets/javascript/head.min.js"></script> <script type="text/javascript">
-      /**
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"></meta>
+
+  <meta
+    http-equiv="X-UA-Compatible"
+    content="IE=edge"
+  ></meta>
+
+  <meta
+    http-equiv="Content-Type"
+    content="text/html; charset=UTF-8"
+  ></meta>
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1"
+  ></meta>
+
+  <title>
+    Linear Advance Calibration Pattern | Marlin Firmware
+  </title>
+
+  <meta
+    property="og:title"
+    content="Linear Advance Calibration Pattern"
+  ></meta>
+
+  <meta
+    name="author"
+    content="MarlinFirmware"
+  ></meta>
+
+  <meta
+    property="og:locale"
+    content="en_US"
+  ></meta>
+
+  <meta
+    name="description"
+    content="Create Gcode to calibrate LIN_ADVANCE setting"
+  ></meta>
+
+  <meta
+    property="og:description"
+    content="Create Gcode to calibrate LIN_ADVANCE setting"
+  ></meta>
+
+  <link
+    rel="canonical"
+    href="http://marlinfw.org/tools/lin_advance/k-factor.html"
+  ></link>
+
+  <meta
+    property="og:url"
+    content="http://marlinfw.org/tools/lin_advance/k-factor.html"
+  ></meta>
+
+  <meta
+    property="og:site_name"
+    content="Marlin Firmware"
+  ></meta>
+
+  <meta
+    property="og:type"
+    content="article"
+  ></meta>
+
+  <meta
+    property="article:published_time"
+    content="2018-10-31T03:43:26+00:00"
+  ></meta>
+
+  <meta
+    name="twitter:card"
+    content="summary"
+  ></meta>
+
+  <meta
+    name="twitter:site"
+    content="@MarlinFirmware"
+  ></meta>
+
+  <meta
+    name="twitter:creator"
+    content="@MarlinFirmware"
+  ></meta>
+
+  <script type="application/ld+json">
+    {"@context":"http://schema.org","@type":"BlogPosting","headline":"Linear Advance Calibration Pattern","author":{"@type":"Person","name":"MarlinFirmware"},"datePublished":"2018-10-31T03:43:26+00:00","dateModified":"2018-10-31T03:43:26+00:00","description":"Create Gcode to calibrate LIN_ADVANCE setting","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"http://marlinfw.org/assets/images/logo/marlin/small.png"},"name":"MarlinFirmware"},"mainEntityOfPage":{"@type":"WebPage","@id":"http://marlinfw.org/tools/lin_advance/k-factor.html"},"url":"http://marlinfw.org/tools/lin_advance/k-factor.html"}
+  </script>
+
+  <link
+    rel="icon"
+    href="/assets/favicon.ico"
+  ></link>
+
+  <link
+    rel="stylesheet"
+    href="/assets/stylesheets/main.css"
+  ></link>
+
+  <!-- [if lt IE 9]><script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script> <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script><![endif] -->
+  <script src="/assets/javascript/head.min.js"></script>
+
+  <script type="text/javascript">
+    /**
        * As Github pages do not support https for custom domains
        * this is the current best workaround for #18.
        */
@@ -38,8 +143,2241 @@
           "dismiss": "Got it!", "learnMore": "More info", "link":"", "theme": "dark-bottom"
         };
       });
-    </script> </head> <body role="document"> <nav class="navbar navbar-default navbar-fixed-top custom-no-margin"> <div class="container"> <div class="navbar-header"> <a href="/" class="navbar-brand"> <img src="/assets/images/logo/marlin/text-25.png" alt="Marlin"> </a> <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="#navbar-main"> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button> </div> <div class="navbar-collapse collapse" id="navbar-main"> <ul class="nav navbar-nav"> <li><a href="/docs/basics/introduction.html">About Marlin</a></li> <li><a href="/meta/download/">Download</a></li> <li><a href="/docs/configuration/configuration.html">Configure</a></li> <li><a href="/docs/basics/install.html">Install</a></li> <li class="dropdown"> <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="navbar-tools">Tools <span class="caret"></span></a> <ul class="dropdown-menu"> <li><a href="/tools/u8glib/converter.html">Bitmap Converter</a></li> <li><a href="/tools/lin_advance/k-factor.html">K-Factor Calibration Pattern</a></li> <li class="divider"> </li> <li><a href="https://github.com/MarlinFirmware/Marlin/issues">Bugtracker</a></li> <li><a href="/docs/basics/reporting_bugs.html">Reporting bugs</a></li> <li class="divider"> </li> <li><a href="https://github.com/MarlinFirmware/Marlin">Source Code Repository</a></li> </ul> </li> <li class="dropdown"> <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="navbar-documentation">Documentation <span class="caret"></span></a> <ul class="dropdown-menu"> <li class="dropdown-submenu configuration"> <a href="#" class="dropdown-toggle" data-toggle="dropdown">Configuration</a> <ul class="dropdown-menu"> <li><a href="/meta/configuration/"> All documents </a></li> <li class="divider"> </li> <li><a href="/docs/configuration/configuration.html"> Configuring Marlin 1.1 </a></li> <li><a href="/docs/configuration/laser_spindle.html"> Laser/Spindle Configuration </a></li> <li><a href="/docs/configuration/probes.html"> Probe Configuration </a></li> </ul> </li> <li class="dropdown-submenu development"> <a href="#" class="dropdown-toggle" data-toggle="dropdown">Development</a> <ul class="dropdown-menu"> <li><a href="/meta/development/"> All documents </a></li> <li class="divider"> </li> <li><a href="/docs/development/boards.html"> Boards </a></li> <li class="divider"> </li> <li><a href="/docs/development/coding_standards.html"> Coding Standards </a></li> <li><a href="/docs/development/getting_started_pull_requests.html"> Contributing Code with Pull Requests </a></li> <li><a href="/docs/development/git_scripts.html"> Marlin Github Scripts </a></li> <li class="divider"> </li> <li><a href="/docs/development/contributing.html"> Contributing to Marlin </a></li> <li><a href="/docs/development/feature_request.html"> Feature requests </a></li> <li class="divider"> </li> <li><a href="/docs/development/fonts.html"> Adding new fonts </a></li> <li><a href="/docs/development/lcd_language.html"> LCD Language System </a></li> </ul> </li> <li class="dropdown-submenu features"> <a href="#" class="dropdown-toggle" data-toggle="dropdown">Features</a> <ul class="dropdown-menu"> <li><a href="/meta/features/"> All documents </a></li> <li class="divider"> </li> <li><a href="/docs/features/auto_bed_leveling.html"> Automatic Bed Leveling </a></li> <li><a href="/docs/features/unified_bed_leveling.html"> Unified Bed Leveling </a></li> <li class="divider"> </li> <li><a href="/docs/features/fwretract.html"> Firmware Retract </a></li> <li><a href="/docs/features/lin_advance.html"> Linear Advance </a></li> <li><a href="/docs/features/tmc_drivers.html"> Trinamic drivers </a></li> <li class="divider"> </li> <li><a href="/docs/features/lcd_menu.html"> LCD Menu Tree </a></li> </ul> </li> <li class="dropdown-submenu gcode"> <a href="#" class="dropdown-toggle" data-toggle="dropdown">G-code</a> <ul class="dropdown-menu"> <li><a href="/meta/gcode/"> All documents </a></li> <li class="divider"> </li> <li><a href="/docs/gcode/G000-G001.html"> G0-G1: Linear Move </a></li> <li><a href="/docs/gcode/G002-G003.html"> G2-G3: Controlled Arc Move </a></li> <li><a href="/docs/gcode/G004.html"> G4: Dwell </a></li> <li><a href="/docs/gcode/G005.html"> G5: Bézier cubic spline </a></li> <li><a href="/docs/gcode/G010.html"> G10: Retract </a></li> <li><a href="/docs/gcode/G011.html"> G11: Recover </a></li> <li><a href="/docs/gcode/G012.html"> G12: Clean the Nozzle </a></li> <li><a href="/docs/gcode/G020.html"> G20: Inch Units </a></li> <li><a href="/docs/gcode/G021.html"> G21: Millimeter Units </a></li> <li><a href="/docs/gcode/G026.html"> G26: Mesh Validation Pattern </a></li> <li><a href="/docs/gcode/G027.html"> G27: Park the nozzle </a></li> <li><a href="/docs/gcode/G028.html"> G28: Auto Home </a></li> <li><a href="/docs/gcode/G029-mbl.html"> G29: Mesh Bed Leveling </a></li> <li><a href="/docs/gcode/G029-abl.html"> G29: Automatic Bed Leveling </a></li> <li><a href="/docs/gcode/G029-ubl.html"> G29: Unified Bed Leveling </a></li> <li><a href="/docs/gcode/G030.html"> G30: Single Z-Probe </a></li> <li><a href="/docs/gcode/G031.html"> G31: Dock Sled </a></li> <li><a href="/docs/gcode/G032.html"> G32: Undock Sled </a></li> <li><a href="/docs/gcode/G033.html"> G33: Delta Auto Calibration </a></li> <li><a href="/docs/gcode/G038.html"> G38.2-G38.3: Probe target </a></li> <li><a href="/docs/gcode/G042.html"> G42: Move to mesh coordinate </a></li> <li><a href="/docs/gcode/G090.html"> G90: Absolute Positioning </a></li> <li><a href="/docs/gcode/G091.html"> G91: Relative Positioning </a></li> <li><a href="/docs/gcode/G092.html"> G92: Set Position </a></li> <li><a href="/docs/gcode/M000-M001.html"> M0-M1: Unconditional stop </a></li> <li><a href="/docs/gcode/M003.html"> M3: Spindle CW / Laser On </a></li> <li><a href="/docs/gcode/M004.html"> M4: Spindle CCW / Laser On </a></li> <li><a href="/docs/gcode/M005.html"> M5: Spindle / Laser Off </a></li> <li><a href="/docs/gcode/M017.html"> M17: Enable Steppers </a></li> <li><a href="/docs/gcode/M018.html"> M18-M84: Disable steppers </a></li> <li><a href="/docs/gcode/M020.html"> M20: List SD Card </a></li> <li><a href="/docs/gcode/M021.html"> M21: Init SD card </a></li> <li><a href="/docs/gcode/M022.html"> M22: Release SD card </a></li> <li><a href="/docs/gcode/M023.html"> M23: Select SD file </a></li> <li><a href="/docs/gcode/M024.html"> M24: Start or Resume SD print </a></li> <li><a href="/docs/gcode/M025.html"> M25: Pause SD print </a></li> <li><a href="/docs/gcode/M026.html"> M26: Set SD position </a></li> <li><a href="/docs/gcode/M027.html"> M27: Report SD print status </a></li> <li><a href="/docs/gcode/M028.html"> M28: Start SD write </a></li> <li><a href="/docs/gcode/M029.html"> M29: Stop SD write </a></li> <li><a href="/docs/gcode/M030.html"> M30: Delete SD file </a></li> <li><a href="/docs/gcode/M031.html"> M31: Print time </a></li> <li><a href="/docs/gcode/M032.html"> M32: Select and Start </a></li> <li><a href="/docs/gcode/M033.html"> M33: Get Long Path </a></li> <li><a href="/docs/gcode/M034.html"> M34: SDCard Sorting </a></li> <li><a href="/docs/gcode/M042.html"> M42: Set Pin State </a></li> <li><a href="/docs/gcode/M043.html"> M43: Debug Pins </a></li> <li><a href="/docs/gcode/M043-T.html"> M43 T: Toggle Details (Debug Pins) </a></li> <li><a href="/docs/gcode/M048.html"> M48: Probe Accuracy Test </a></li> <li><a href="/docs/gcode/M073.html"> M73: Set Print Progress </a></li> <li><a href="/docs/gcode/M075.html"> M75: Start Print Job </a></li> <li><a href="/docs/gcode/M076.html"> M76: Pause Print Job </a></li> <li><a href="/docs/gcode/M077.html"> M77: Stop Print Job </a></li> <li><a href="/docs/gcode/M078.html"> M78: Print Job Stats </a></li> <li><a href="/docs/gcode/M080.html"> M80: Power On </a></li> <li><a href="/docs/gcode/M081.html"> M81: Power Off </a></li> <li><a href="/docs/gcode/M082.html"> M82: E Absolute </a></li> <li><a href="/docs/gcode/M083.html"> M83: E Relative </a></li> <li><a href="/docs/gcode/M085.html"> M85: Inactivity Shutdown </a></li> <li><a href="/docs/gcode/M092.html"> M92: Set Axis Steps-per-unit </a></li> <li><a href="/docs/gcode/M100.html"> M100: Free Memory </a></li> <li><a href="/docs/gcode/M104.html"> M104: Set Hotend Temperature </a></li> <li><a href="/docs/gcode/M105.html"> M105: Report Temperatures </a></li> <li><a href="/docs/gcode/M106.html"> M106: Set Fan Speed </a></li> <li><a href="/docs/gcode/M107.html"> M107: Fan Off </a></li> <li><a href="/docs/gcode/M108.html"> M108: Break and Continue </a></li> <li><a href="/docs/gcode/M109.html"> M109: Wait for Hotend Temperature </a></li> <li><a href="/docs/gcode/M110.html"> M110: Set Line Number </a></li> <li><a href="/docs/gcode/M111.html"> M111: Debug Level </a></li> <li><a href="/docs/gcode/M112.html"> M112: Emergency Stop </a></li> <li><a href="/docs/gcode/M113.html"> M113: Host Keepalive </a></li> <li><a href="/docs/gcode/M114.html"> M114: Get Current Position </a></li> <li><a href="/docs/gcode/M115.html"> M115: Firmware Info </a></li> <li><a href="/docs/gcode/M117.html"> M117: Set LCD Message </a></li> <li><a href="/docs/gcode/M118.html"> M118: Serial print </a></li> <li><a href="/docs/gcode/M119.html"> M119: Endstop States </a></li> <li><a href="/docs/gcode/M120.html"> M120: Enable Endstops </a></li> <li><a href="/docs/gcode/M121.html"> M121: Disable Endstops </a></li> <li><a href="/docs/gcode/M122.html"> M122: TMC Debugging </a></li> <li><a href="/docs/gcode/M125.html"> M125: Park Head </a></li> <li><a href="/docs/gcode/M126.html"> M126: Baricuda 1 Open </a></li> <li><a href="/docs/gcode/M127.html"> M127: Baricuda 1 Close </a></li> <li><a href="/docs/gcode/M128.html"> M128: Baricuda 2 Open </a></li> <li><a href="/docs/gcode/M129.html"> M129: Baricuda 2 Close </a></li> <li><a href="/docs/gcode/M140.html"> M140: Set Bed Temperature </a></li> <li><a href="/docs/gcode/M145.html"> M145: Set Material Preset </a></li> <li><a href="/docs/gcode/M149.html"> M149: Set Temperature Units </a></li> <li><a href="/docs/gcode/M150.html"> M150: Set RGB(W) Color </a></li> <li><a href="/docs/gcode/M155.html"> M155: Temperature Auto-Report </a></li> <li><a href="/docs/gcode/M163.html"> M163: Set Mix Factor </a></li> <li><a href="/docs/gcode/M164.html"> M164: Save Mix </a></li> <li><a href="/docs/gcode/M165.html"> M165: Set Mix </a></li> <li><a href="/docs/gcode/M190.html"> M190: Wait for Bed Temperature </a></li> <li><a href="/docs/gcode/M200.html"> M200: Set Filament Diameter </a></li> <li><a href="/docs/gcode/M201.html"> M201: Set Print Max Acceleration </a></li> <li><a href="/docs/gcode/M203.html"> M203: Set Max Feedrate </a></li> <li><a href="/docs/gcode/M204.html"> M204: Set Starting Acceleration </a></li> <li><a href="/docs/gcode/M205.html"> M205: Set Advanced Settings </a></li> <li><a href="/docs/gcode/M206.html"> M206: Set Home Offsets </a></li> <li><a href="/docs/gcode/M207.html"> M207: Set Firmware Retraction </a></li> <li><a href="/docs/gcode/M208.html"> M208: Set Firmware Recovery </a></li> <li><a href="/docs/gcode/M209.html"> M209: Set Auto Retract </a></li> <li><a href="/docs/gcode/M211.html"> M211: Software Endstops </a></li> <li><a href="/docs/gcode/M217.html"> M217: Filament swap parameters </a></li> <li><a href="/docs/gcode/M218.html"> M218: Set Hotend Offset </a></li> <li><a href="/docs/gcode/M220.html"> M220: Set Feedrate Percentage </a></li> <li><a href="/docs/gcode/M221.html"> M221: Set Flow Percentage </a></li> <li><a href="/docs/gcode/M226.html"> M226: Wait for Pin State </a></li> <li><a href="/docs/gcode/M240.html"> M240: Trigger Camera </a></li> <li><a href="/docs/gcode/M250.html"> M250: LCD Contrast </a></li> <li><a href="/docs/gcode/M260.html"> M260: I2C Send </a></li> <li><a href="/docs/gcode/M261.html"> M261: I2C Request </a></li> <li><a href="/docs/gcode/M280.html"> M280: Servo Position </a></li> <li><a href="/docs/gcode/M290.html"> M290: Babystep </a></li> <li><a href="/docs/gcode/M300.html"> M300: Play Tone </a></li> <li><a href="/docs/gcode/M301.html"> M301: Set Hotend PID </a></li> <li><a href="/docs/gcode/M302.html"> M302: Cold Extrude </a></li> <li><a href="/docs/gcode/M303.html"> M303: PID autotune </a></li> <li><a href="/docs/gcode/M304.html"> M304: Set Bed PID </a></li> <li><a href="/docs/gcode/M350.html"> M350: Set micro-stepping </a></li> <li><a href="/docs/gcode/M351.html"> M351: Set Microstep Pins </a></li> <li><a href="/docs/gcode/M355.html"> M355: Case Light Control </a></li> <li><a href="/docs/gcode/M360.html"> M360: SCARA Theta A </a></li> <li><a href="/docs/gcode/M361.html"> M361: SCARA Theta-B </a></li> <li><a href="/docs/gcode/M362.html"> M362: SCARA Psi-A </a></li> <li><a href="/docs/gcode/M363.html"> M363: SCARA Psi-B </a></li> <li><a href="/docs/gcode/M364.html"> M364: SCARA Psi-C </a></li> <li><a href="/docs/gcode/M380.html"> M380: Activate Solenoid </a></li> <li><a href="/docs/gcode/M381.html"> M381: Deactivate Solenoids </a></li> <li><a href="/docs/gcode/M400.html"> M400: Finish Moves </a></li> <li><a href="/docs/gcode/M401.html"> M401: Deploy Probe </a></li> <li><a href="/docs/gcode/M402.html"> M402: Stow Probe </a></li> <li><a href="/docs/gcode/M404.html"> M404: Set Filament Diameter </a></li> <li><a href="/docs/gcode/M405.html"> M405: Filament Width Sensor On </a></li> <li><a href="/docs/gcode/M406.html"> M406: Filament Width Sensor Off </a></li> <li><a href="/docs/gcode/M407.html"> M407: Filament Width </a></li> <li><a href="/docs/gcode/M410.html"> M410: Quickstop </a></li> <li><a href="/docs/gcode/M420.html"> M420: Bed Leveling State </a></li> <li><a href="/docs/gcode/M421.html"> M421: Set Mesh Value </a></li> <li><a href="/docs/gcode/M428.html"> M428: Home Offsets Here </a></li> <li><a href="/docs/gcode/M500.html"> M500: Save Settings </a></li> <li><a href="/docs/gcode/M501.html"> M501: Restore Settings </a></li> <li><a href="/docs/gcode/M502.html"> M502: Factory Reset </a></li> <li><a href="/docs/gcode/M503.html"> M503: Report Settings </a></li> <li><a href="/docs/gcode/M504.html"> M504: Validate EEPROM contents </a></li> <li><a href="/docs/gcode/M524.html"> M524: Abort SD print </a></li> <li><a href="/docs/gcode/M540.html"> M540: Endstops Abort SD </a></li> <li><a href="/docs/gcode/M600.html"> M600: Filament Change </a></li> <li><a href="/docs/gcode/M603.html"> M603: Configure Filament Change </a></li> <li><a href="/docs/gcode/M605.html"> M605: Dual Nozzle Mode </a></li> <li><a href="/docs/gcode/M665.html"> M665: Delta Configuration </a></li> <li><a href="/docs/gcode/M665-scara.html"> M665: SCARA Configuration </a></li> <li><a href="/docs/gcode/M666.html"> M666: Set Delta endstop adjustments </a></li> <li><a href="/docs/gcode/M666-dual.html"> M666: Set dual endstop offsets </a></li> <li><a href="/docs/gcode/M851.html"> M851: Z Probe Offset </a></li> <li><a href="/docs/gcode/M852.html"> M852: Bed Skew Compensation </a></li> <li><a href="/docs/gcode/M900.html"> M900: Linear Advance Factor </a></li> <li><a href="/docs/gcode/M906.html"> M906: TMC Motor Current </a></li> <li><a href="/docs/gcode/M907.html"> M907: Set Motor Current </a></li> <li><a href="/docs/gcode/M908.html"> M908: Set Trimpot Pins </a></li> <li><a href="/docs/gcode/M909.html"> M909: DAC Print Values </a></li> <li><a href="/docs/gcode/M910.html"> M910: Commit DAC to EEPROM </a></li> <li><a href="/docs/gcode/M911.html"> M911: TMC OT Pre-Warn Condition </a></li> <li><a href="/docs/gcode/M912.html"> M912: Clear TMC OT Pre-Warn </a></li> <li><a href="/docs/gcode/M913.html"> M913: Set Hybrid Threshold Speed </a></li> <li><a href="/docs/gcode/M914.html"> M914: TMC Bump Sensitivity </a></li> <li><a href="/docs/gcode/M915.html"> M915: TMC Z axis calibration </a></li> <li><a href="/docs/gcode/M928.html"> M928: Start SD Logging </a></li> <li><a href="/docs/gcode/M999.html"> M999: STOP Restart </a></li> </ul> </li> <li class="dropdown-submenu hardware"> <a href="#" class="dropdown-toggle" data-toggle="dropdown">Hardware</a> <ul class="dropdown-menu"> <li><a href="/meta/hardware/"> All documents </a></li> <li class="divider"> </li> <li><a href="/docs/hardware/boards.html"> Boards </a></li> <li><a href="/docs/hardware/endstops.html"> Endstops </a></li> <li><a href="/docs/hardware/tmc_drivers.html"> Trinamic drivers </a></li> </ul> </li> <li class="divider"> </li> <li><a href="/meta/needs-review/">Documentation Needing Review</a></li> </ul> </li> </ul> <ul class="nav navbar-nav navbar-right visible-lg-block"> <li><a href="https://github.com/MarlinFirmware/MarlinDocumentation/edit/master/_tools/lin_advance/k-factor.html" data-proofer-ignore> <i class="fa fa-pencil-square-o" aria-hidden="true"></i> <span>Improve this page</span> </a></li> </ul> </div> </div> </nav> <script language="JavaScript" type="text/javascript" src="/assets/javascript/jquery-2.2.1.min.js"></script> <script language="JavaScript" type="text/javascript" src="/assets/javascript/jquery-ui.min.js"></script> <script language="JavaScript" type="text/javascript" src="./FileSaver.min.js"></script> <script language="JavaScript" type="text/javascript" src="./k-factor.js"></script> <div class="container" role="main"> <div class="row"> <div class="calibpat" id="calibpat"> <h1>K-factor Calibration Pattern</h1> <div class="row alert alert-info custom-alert"> <div class="col-lg-1 col-md-2 visible-lg-block visible-md-block custom-alert-icon"> <i class="fa fa-info-circle fa-4x" aria-hidden="true"></i> </div> <div class="col-lg-11 col-md-10 custom-alert-text"> <p>There are two versions of Linear Advance. Linear Advance 1.0 is in Marlin 1.1.8 and earlier. Marlin 1.1.9 and up have Linear Advance 1.5.</p> </div> </div> <p>The Javascript below generates G-code to calibrate the Linear Advance K-factor. The default values apply to typical PLA with a 0.4mm nozzle.</p> <p>Press the <code class="highlighter-rouge">Generate G-code</code> button then use <code class="highlighter-rouge">Download as file</code> to save the result.</p> <table> <tbody> <tr> <td colspan="3" class="tdHead"><h3>Settings</h3></td> <td class="tdHead"><h3>G-code</h3></td> </tr> <tr> <td colspan="3" class="tdSection"><h4>Printer:</h4></td> <td rowspan="45" class="txtareatd"><textarea name="textarea" id="textarea"></textarea></td> </tr> <tr> <td><label for="FIL_DIA">Filament Diameter:</label></td> <td><input name="FIL_DIA" type="number" id="FIL_DIA" step="any" value="1.75"></td> <td>Diameter of the used filament (mm)</td> </tr> <tr> <td><label for="NOZ_DIA">Nozzle Diameter:</label></td> <td><input name="NOZ_DIA" type="number" id="NOZ_DIA" step="any" value="0.4"></td> <td>Diameter of the nozzle (mm)</td> </tr> <tr> <td><label for="NOZZLE_TEMP">Nozzle Temperature:</label></td> <td><input name="NOZZLE_TEMP" type="number" id="NOZZLE_TEMP" step="any" value="205"></td> <td>Nozzle Temperature (°C)</td> </tr> <tr> <td><label for="BED_TEMP">Bed Temperature:</label></td> <td><input name="BED_TEMP" type="number" id="BED_TEMP" step="any" value="60"></td> <td>Bed Temperature (°C)</td> </tr> <tr> <td><label for="RETRACTION">Retraction Distance:</label></td> <td><input name="RETRACTION" type="number" id="RETRACTION" step="any" value="1"></td> <td>Retraction distance (mm)</td> </tr> <tr> <td><label for="LAYER_HEIGHT">Layer Height:</label></td> <td><input name="LAYER_HEIGHT" type="number" id="LAYER_HEIGHT" step="0.1" value="0.2"></td> <td>Layer Height (mm)</td> </tr> <tr> <td colspan="3" class="tdSection"><h4>Print Bed:</h4></td> </tr> <tr> <td><label for="SHAPE_BED">Bed Shape:</label></td> <td><select name="SHAPE_BED" id="SHAPE_BED"> <option value="Rect">Rectangular</option> <option value="Round">Round</option> </select></td> <td>Rectangular or round bed. Round beds will activate Origin Bed Center</td> </tr> <tr> <td><label for="BEDSIZE_X">Bed Size X:</label></td> <td><input name="BEDSIZE_X" type="number" id="BEDSIZE_X" step="any" value="200"></td> <td id="shape">Size (mm) of the bed in X</td> </tr> <tr> <td><label for="BEDSIZE_Y">Bed Size Y:</label></td> <td><input name="BEDSIZE_Y" type="number" id="BEDSIZE_Y" step="any" value="200"></td> <td>Size (mm) of the bed in Y</td> </tr> <tr> <td><label for="CENTER_NULL">Origin Bed Center:</label></td> <td><input name="CENTER_NULL" type="checkbox" id="CENTER_NULL"></td> <td>Set the origin position (X0 Y0) to bed center instead of front-left corner</td> </tr> <tr> <td colspan="3" class="tdSection"><h4>Speed:</h4></td> </tr> <tr> <td><label for="MM_S">Use mm/s: </label></td> <td><input name="MM_S" type="checkbox" id="MM_S" checked></td> <td>Use mm/s instead of mm/min</td> </tr> <tr> <td><label for="SLOW_SPEED">Slow Printing Speed:</label></td> <td><input name="SLOW_SPEED" type="number" id="SLOW_SPEED" step="any" value="20"></td> <td>Slow printing speed</td> </tr> <tr> <td><label for="FAST_SPEED">Fast Printing Speed:</label></td> <td><input name="FAST_SPEED" type="number" id="FAST_SPEED" step="any" value="70"></td> <td>Fast printing speed. This should differ noticeably from Slow Speed</td> </tr> <tr> <td><label for="MOVE_SPEED">Movement Speed:</label></td> <td><input name="MOVE_SPEED" type="number" id="MOVE_SPEED" step="any" value="120"></td> <td>Movement speed</td> </tr> <tr> <td><label for="RETRACT_SPEED">Retract Speed:</label></td> <td><input name="RETRACT_SPEED" type="number" id="RETRACT_SPEED" step="any" value="30"></td> <td>Retract Speed of the extruder</td> </tr> <tr> <td><label for="PRINT_ACCL">Acceleration:</label></td> <td><input name="PRINT_ACCL" type="number" id="PRINT_ACCL" step="any" value="500"></td> <td>Set printing acceleration (mm/s^2)</td> </tr> <tr> <td><label for="X_JERK">Jerk X:</label></td> <td><input name="X_JERK" type="number" id="X_JERK" step="1" value="-1"></td> <td>Set the Jerk for the X-axis. -1 to use firmware default</td> </tr> <tr> <td><label for="Y_JERK">Jerk Y:</label></td> <td><input name="Y_JERK" type="number" id="Y_JERK" step="1" value="-1"></td> <td>Set the Jerk for the Y-axis. -1 to use firmware default</td> </tr> <tr> <td><label for="Z_JERK">Jerk Z:</label></td> <td><input name="Z_JERK" type="number" id="Z_JERK" step="1" value="-1"></td> <td>Set the Jerk for the Z-axis. -1 to use firmware default</td> </tr> <tr> <td><label for="E_JERK">Jerk E:</label></td> <td><input name="E_JERK" type="number" id="E_JERK" step="1" value="-1"></td> <td>Set the Jerk for the Extruder. -1 to use firmware default</td> </tr> <tr> <td colspan="3" class="tdSection"><h4>Pattern:</h4></td> </tr> <tr> <td><label for="LIN_VERSION">Lin Advance Version:</label></td> <td><select name="LIN_VERSION" id="LIN_VERSION"> <option value="1.0">1.0</option> <option value="1.5" selected>1.5</option> </select></td> <td>Select version 1.0 for Marlin 1.1.8 and earlier. Select 1.5 for Marlin 1.1.9 / 2.0 and up</td> </tr> <tr> <td><label for="TYPE_PATTERN">Pattern Type:</label></td> <td><select name="TYPE_PATTERN" id="TYPE_PATTERN"> <option value="std">Standard</option> <option value="alt">Alternate</option> </select></td> <td>Select standard or alternate pattern</td> </tr> <tr> <td><label for="K_START">Starting Value for K:</label></td> <td><input name="K_START" type="number" id="K_START" step="any" value="0" onblur="validateInput()"></td> <td id="start_factor">Starting value for the K-factor. Usually 0 but for bowden setups you might want to start higher, e.g. 30</td> </tr> <tr> <td><label for="K_END">Ending Value for K:</label></td> <td><input name="K_END" type="number" id="K_END" step="any" value="2" onblur="validateInput()"></td> <td id="end_factor">Ending value of the K-factor. Bowden setups may be higher than 100</td> </tr> <tr> <td><label for="K_STEP">K-factor Stepping:</label></td> <td><input name="K_STEP" type="number" id="K_STEP" step="any" value="0.2" onblur="validateInput()"></td> <td id="step_factor">Stepping of the K-factor in the test pattern. Needs to be an exact divisor of the K-factor Range (End - Start)</td> </tr> <tr> <td><label for="SLOW_LENGTH">Slow Speed Length:</label></td> <td><input name="SLOW_LENGTH" type="number" id="SLOW_LENGTH" step="1" value="20" onblur="validateInput()"></td> <td>Length of the Slow Speed test-line (mm)</td> </tr> <tr> <td><label for="FAST_LENGTH">Fast Speed Length:</label></td> <td><input name="FAST_LENGTH" type="number" id="FAST_LENGTH" step="1" value="40" onblur="validateInput()"></td> <td>Length of the Fast Speed test-line (mm)</td> </tr> <tr> <td><label for="SPACE_LINE">Test Line Spacing:</label></td> <td><input name="SPACE_LINE" type="number" id="SPACE_LINE" step="0.1" value="5" onblur="validateInput()"></td> <td>Distance between the test lines. This will impact print size</td> </tr> <tr> <td><label for="FRAME">Print Anchor Frame:</label></td> <td><input name="FRAME" type="checkbox" id="FRAME"></td> <td>Adds a frame around the start and end points of the test lines. May improve adhesion</td> </tr> <tr> <td><label for="DIR_PRINT">Printing Direction:</label></td> <td><select name="DIR_PRINT" id="DIR_PRINT" onchange="validateInput()"> <option value="0" selected>Left to Right (0°)</option> <option value="45">45°</option> <option value="90">Front to Back (90°)</option> <option value="135">135°</option> <option value="180">Right to Left (180°)</option> <option value="225">225°</option> <option value="270">Back to Front (270°)</option> <option value="315">315°</option> </select></td> <td>Rotates the print in 45° steps</td> </tr> <tr> <td><label for="LINE_NO">Line Numbering:</label></td> <td><input name="LINE_NO" type="checkbox" id="LINE_NO" checked></td> <td>Prints the K-value besides every second test line</td> </tr> <tr> <td colspan="3" class="tdSection"><h4>Advanced:</h4></td> </tr> <tr> <td><label for="NOZ_LIN_R">Nozzle Line Ratio:</label></td> <td><input name="NOZ_LIN_R" type="number" id="NOZ_LIN_R" step="0.1" value="1.2"></td> <td>Ratio between extruded line width and nozzle diameter. Should be between 1.05 and 1.2</td> </tr> <tr> <td><label for="OFFSET_Z">Z-Offset:</label></td> <td><input name="OFFSET_Z" type="number" id="OFFSET_Z" step="any" value="0"></td> <td>Offset the Z-axis for manual Layer adjustment</td> </tr> <tr> <td><label for="USE_BL">Use Bed Leveling:</label></td> <td><input name="USE_BL" type="checkbox" id="USE_BL"></td> <td>Level bed before printing. Bed leveling has to be activated</td> </tr> <tr> <td><label for="USE_FWR">Use FW Retract </label></td> <td><input type="checkbox" name="USE_FWR" id="USE_FWR"></td> <td>Use Firmware Retract. Needs to be activated in Marlin</td> </tr> <tr> <td><label for="EXTRUSION_MULT">Extrusion Multiplier:</label></td> <td><input name="EXTRUSION_MULT" type="number" id="EXTRUSION_MULT" step="0.1" value="1.0"></td> <td>Usually 1.0</td> </tr> <tr> <td><label for="PRIME">Prime Nozzle:</label></td> <td><input name="PRIME" type="checkbox" id="PRIME" checked></td> <td>Prime the nozzle before starting the test pattern</td> </tr> <tr> <td><label for="PRIME_EXT">Prime Extrusion Multiplier:</label></td> <td><input name="PRIME_EXT" type="number" id="PRIME_EXT" step="0.1" value="2.5"></td> <td>The default of 2.5 results in roughly 1mm of filament for 10mm line length</td> </tr> <tr> <td height="24"><label for="PRIME_SPEED">Prime Printing Speed:</label></td> <td><input name="PRIME_SPEED" type="number" id="PRIME_SPEED" step="any" value="30"></td> <td>Speed of the prime move</td> </tr> <tr> <td><label for="DWELL_PRIME">Dwell Time:</label></td> <td><input name="DWELL_PRIME" type="number" id="DWELL_PRIME" step="0.1" value="2"></td> <td>Inserts a pause of x seconds before starting the test pattern to bleed off any residual nozzle pressure</td> </tr> <tr class="calibpat2"> <td colspan="3"> <p> <input name="button" type="button" id="button" onclick="genGcode()" value="Generate G-code"> <input name="button3" type="button" id="button3" onclick="setLocalStorage()" value="Save as default"> </p> <p id="warning1" style="display: none;">warning</p> <p id="warning2" style="display: none;">warning</p> </td> <td><p> <input name="button2" type="button" id="button2" onclick="saveTextAsFile()" value="Download as file"> </p></td> </tr> </tbody> </table> <h3>Notes on the settings:</h3> <ul> <li> <code class="highlighter-rouge">Fast Printing Speed</code> and <code class="highlighter-rouge">Slow Printing Speed</code> should be significantly different or the K-factor effect will barely be visible.</li> <li> <code class="highlighter-rouge">Use Bed Leveling</code> requires a probe.</li> <li>For round beds the option <code class="highlighter-rouge">Origin Bed Center</code> is automatically activated.</li> <li>The overall width (X-direction) of the print depends on the <code class="highlighter-rouge">Fast Speed Length</code> and <code class="highlighter-rouge">Slow Speed Length</code> settings plus 5mm for the priming line. The length (Y-direction) depends on the K-factor Settings and <code class="highlighter-rouge">Line Spacing</code>.</li> <li>The script checks to make sure the print fits on the bed. Verify it using a host software like <a href="http://www.pronterface.com/" target="new">Printrun</a> or <a href="https://www.repetier.com/" target="new">Repetier Host</a>.</li> <li> <code class="highlighter-rouge">Start</code> and <code class="highlighter-rouge">End Value</code> for the K-factor determines the range that the test pattern will cover. For example a <code class="highlighter-rouge">Start Value</code> of 50 and an <code class="highlighter-rouge">End Value</code> of 150 will test a range of 100.</li> <li>The <code class="highlighter-rouge">K-factor Stepping</code> determines how many test lines are printed for the above range. For example, a Stepping of 10 and a range of 100 results in 10 test lines. A stepping of 3 would not work in this example as 100 cannot be exactly divided by 3. The script will throw an error message if an exact division is not possible. In this case either the range or the stepping needs to be adjusted.</li> <li>The <code class="highlighter-rouge">Alternate Pattern</code> has a second line of <code class="highlighter-rouge">Fast Printing Speed</code> to test 0 to <code class="highlighter-rouge">Fast Printing Speed</code> and back to 0 conditions. Best used with an increased <code class="highlighter-rouge">Test Line Spacing</code> and reduced K-factor range.</li> <li>The proper K-factor depends on the filament, nozzle size, nozzle geometry and printing temperature. If any of these values change, the calibration might need to be repeated.</li> </ul> <h2>Screen-shots</h2> <p>The following screen-shots show some examples of the test patterns</p> <ul> <li>Blue Lines are Slow Printing Speeds</li> <li>Red Lines are Fast Printing Speed</li> <li>Light blue lines are movements</li> </ul> <h3>Standard Pattern</h3> <p><img src="/assets/images/features/lin_advance/std_pattern.png" alt="StandardPattern"></p> <br> <h3>Alternate Pattern with increased Test Line Spacing</h3> <p><img src="/assets/images/features/lin_advance/alt_pattern.png" alt="AlternatePattern"></p> <br> <h3>Standard Pattern with Frame</h3> <p><img src="/assets/images/features/lin_advance/frame_pattern.png" alt="FramePattern"></p> <br> <h3>45° rotated Alternate Pattern</h3> <p><img src="/assets/images/features/lin_advance/rot_pattern.png" alt="RotatedPattern"></p> </div> </div> </div> } <footer> <div class="container"> <div class="row"> <div class="col-lg-12"> <hr> </div> </div> <div class="row"> <div class="col-lg-8"> <p>Brought to you with <i class="fa fa-heart text-danger" aria-hidden="true"></i> lack of <i class="fa fa-bed" aria-hidden="true"></i> and lots of <i class="fa fa-coffee" aria-hidden="true"></i>. <br> The contents of this website are © 2018 under the terms of the <a href="http://www.gnu.org/licenses/gpl-3.0.txt">GPLv3</a> License.</p> </div> <div class="col-lg-4"> <div class="pull-right"> <a href="#top" data-proofer-ignore> Back to top <i class="fa fa-level-up" aria-hidden="true"></i></a> </div> </div> </div> </div> </footer> <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  </script>
+</head>
+
+<body role="document">
+  <nav class="navbar navbar-default navbar-fixed-top custom-no-margin">
+    <div class="container">
+      <div class="navbar-header">
+        <a
+          href="/"
+          class="navbar-brand"
+        >
+          <img
+            src="/assets/images/logo/marlin/text-25.png"
+            alt="Marlin"
+          >
+        </a>
+
+        <button
+          class="navbar-toggle"
+          type="button"
+          data-toggle="collapse"
+          data-target="#navbar-main"
+        >
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+      </div>
+
+      <div
+        class="navbar-collapse collapse"
+        id="navbar-main"
+      >
+        <ul class="nav navbar-nav">
+          <li>
+            <a href="/docs/basics/introduction.html">About Marlin</a>
+          </li>
+
+          <li>
+            <a href="/meta/download/">Download</a>
+          </li>
+
+          <li>
+            <a href="/docs/configuration/configuration.html">Configure</a>
+          </li>
+
+          <li>
+            <a href="/docs/basics/install.html">Install</a>
+          </li>
+
+          <li class="dropdown">
+            <a
+              class="dropdown-toggle"
+              data-toggle="dropdown"
+              href="#"
+              id="navbar-tools"
+            >
+              Tools
+
+              <span class="caret"></span>
+            </a>
+
+            <ul class="dropdown-menu">
+              <li>
+                <a href="/tools/u8glib/converter.html">Bitmap Converter</a>
+              </li>
+
+              <li>
+                <a href="/tools/lin_advance/k-factor.html">K-Factor Calibration Pattern</a>
+              </li>
+
+              <li class="divider"></li>
+
+              <li>
+                <a href="https://github.com/MarlinFirmware/Marlin/issues">Bugtracker</a>
+              </li>
+
+              <li>
+                <a href="/docs/basics/reporting_bugs.html">Reporting bugs</a>
+              </li>
+
+              <li class="divider"></li>
+
+              <li>
+                <a href="https://github.com/MarlinFirmware/Marlin">Source Code Repository</a>
+              </li>
+            </ul>
+          </li>
+
+          <li class="dropdown">
+            <a
+              class="dropdown-toggle"
+              data-toggle="dropdown"
+              href="#"
+              id="navbar-documentation"
+            >
+              Documentation
+
+              <span class="caret"></span>
+            </a>
+
+            <ul class="dropdown-menu">
+              <li class="dropdown-submenu configuration">
+                <a
+                  href="#"
+                  class="dropdown-toggle"
+                  data-toggle="dropdown"
+                >Configuration</a>
+
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="/meta/configuration/">All documents</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/configuration/configuration.html">Configuring Marlin 1.1</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/configuration/laser_spindle.html">Laser/Spindle Configuration</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/configuration/probes.html">Probe Configuration</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li class="dropdown-submenu development">
+                <a
+                  href="#"
+                  class="dropdown-toggle"
+                  data-toggle="dropdown"
+                >Development</a>
+
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="/meta/development/">All documents</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/development/boards.html">Boards</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/development/coding_standards.html">Coding Standards</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/development/getting_started_pull_requests.html">
+                      Contributing Code with Pull Requests
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/development/git_scripts.html">Marlin Github Scripts</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/development/contributing.html">Contributing to Marlin</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/development/feature_request.html">Feature requests</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/development/fonts.html">Adding new fonts</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/development/lcd_language.html">LCD Language System</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li class="dropdown-submenu features">
+                <a
+                  href="#"
+                  class="dropdown-toggle"
+                  data-toggle="dropdown"
+                >Features</a>
+
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="/meta/features/">All documents</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/features/auto_bed_leveling.html">Automatic Bed Leveling</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/features/unified_bed_leveling.html">Unified Bed Leveling</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/features/fwretract.html">Firmware Retract</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/features/lin_advance.html">Linear Advance</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/features/tmc_drivers.html">Trinamic drivers</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/features/lcd_menu.html">LCD Menu Tree</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li class="dropdown-submenu gcode">
+                <a
+                  href="#"
+                  class="dropdown-toggle"
+                  data-toggle="dropdown"
+                >G-code</a>
+
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="/meta/gcode/">All documents</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/gcode/G000-G001.html">G0-G1: Linear Move</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G002-G003.html">G2-G3: Controlled Arc Move</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G004.html">G4: Dwell</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G005.html">G5: Bézier cubic spline</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G010.html">G10: Retract</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G011.html">G11: Recover</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G012.html">G12: Clean the Nozzle</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G020.html">G20: Inch Units</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G021.html">G21: Millimeter Units</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G026.html">G26: Mesh Validation Pattern</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G027.html">G27: Park the nozzle</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G028.html">G28: Auto Home</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G029-mbl.html">G29: Mesh Bed Leveling</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G029-abl.html">G29: Automatic Bed Leveling</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G029-ubl.html">G29: Unified Bed Leveling</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G030.html">G30: Single Z-Probe</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G031.html">G31: Dock Sled</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G032.html">G32: Undock Sled</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G033.html">G33: Delta Auto Calibration</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G038.html">G38.2-G38.3: Probe target</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G042.html">G42: Move to mesh coordinate</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G090.html">G90: Absolute Positioning</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G091.html">G91: Relative Positioning</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/G092.html">G92: Set Position</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M000-M001.html">M0-M1: Unconditional stop</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M003.html">M3: Spindle CW / Laser On</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M004.html">M4: Spindle CCW / Laser On</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M005.html">M5: Spindle / Laser Off</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M017.html">M17: Enable Steppers</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M018.html">M18-M84: Disable steppers</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M020.html">M20: List SD Card</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M021.html">M21: Init SD card</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M022.html">M22: Release SD card</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M023.html">M23: Select SD file</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M024.html">M24: Start or Resume SD print</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M025.html">M25: Pause SD print</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M026.html">M26: Set SD position</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M027.html">M27: Report SD print status</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M028.html">M28: Start SD write</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M029.html">M29: Stop SD write</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M030.html">M30: Delete SD file</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M031.html">M31: Print time</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M032.html">M32: Select and Start</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M033.html">M33: Get Long Path</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M034.html">M34: SDCard Sorting</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M042.html">M42: Set Pin State</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M043.html">M43: Debug Pins</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M043-T.html">
+                      M43 T: Toggle Details (Debug Pins)
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M048.html">M48: Probe Accuracy Test</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M073.html">M73: Set Print Progress</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M075.html">M75: Start Print Job</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M076.html">M76: Pause Print Job</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M077.html">M77: Stop Print Job</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M078.html">M78: Print Job Stats</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M080.html">M80: Power On</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M081.html">M81: Power Off</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M082.html">M82: E Absolute</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M083.html">M83: E Relative</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M085.html">M85: Inactivity Shutdown</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M092.html">M92: Set Axis Steps-per-unit</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M100.html">M100: Free Memory</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M104.html">M104: Set Hotend Temperature</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M105.html">M105: Report Temperatures</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M106.html">M106: Set Fan Speed</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M107.html">M107: Fan Off</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M108.html">M108: Break and Continue</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M109.html">
+                      M109: Wait for Hotend Temperature
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M110.html">M110: Set Line Number</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M111.html">M111: Debug Level</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M112.html">M112: Emergency Stop</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M113.html">M113: Host Keepalive</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M114.html">M114: Get Current Position</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M115.html">M115: Firmware Info</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M117.html">M117: Set LCD Message</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M118.html">M118: Serial print</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M119.html">M119: Endstop States</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M120.html">M120: Enable Endstops</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M121.html">M121: Disable Endstops</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M122.html">M122: TMC Debugging</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M125.html">M125: Park Head</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M126.html">M126: Baricuda 1 Open</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M127.html">M127: Baricuda 1 Close</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M128.html">M128: Baricuda 2 Open</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M129.html">M129: Baricuda 2 Close</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M140.html">M140: Set Bed Temperature</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M145.html">M145: Set Material Preset</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M149.html">M149: Set Temperature Units</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M150.html">M150: Set RGB(W) Color</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M155.html">M155: Temperature Auto-Report</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M163.html">M163: Set Mix Factor</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M164.html">M164: Save Mix</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M165.html">M165: Set Mix</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M190.html">
+                      M190: Wait for Bed Temperature
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M200.html">M200: Set Filament Diameter</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M201.html">
+                      M201: Set Print Max Acceleration
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M203.html">M203: Set Max Feedrate</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M204.html">
+                      M204: Set Starting Acceleration
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M205.html">M205: Set Advanced Settings</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M206.html">M206: Set Home Offsets</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M207.html">M207: Set Firmware Retraction</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M208.html">M208: Set Firmware Recovery</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M209.html">M209: Set Auto Retract</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M211.html">M211: Software Endstops</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M217.html">
+                      M217: Filament swap parameters
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M218.html">M218: Set Hotend Offset</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M220.html">M220: Set Feedrate Percentage</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M221.html">M221: Set Flow Percentage</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M226.html">M226: Wait for Pin State</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M240.html">M240: Trigger Camera</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M250.html">M250: LCD Contrast</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M260.html">M260: I2C Send</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M261.html">M261: I2C Request</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M280.html">M280: Servo Position</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M290.html">M290: Babystep</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M300.html">M300: Play Tone</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M301.html">M301: Set Hotend PID</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M302.html">M302: Cold Extrude</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M303.html">M303: PID autotune</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M304.html">M304: Set Bed PID</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M350.html">M350: Set micro-stepping</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M351.html">M351: Set Microstep Pins</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M355.html">M355: Case Light Control</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M360.html">M360: SCARA Theta A</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M361.html">M361: SCARA Theta-B</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M362.html">M362: SCARA Psi-A</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M363.html">M363: SCARA Psi-B</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M364.html">M364: SCARA Psi-C</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M380.html">M380: Activate Solenoid</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M381.html">M381: Deactivate Solenoids</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M400.html">M400: Finish Moves</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M401.html">M401: Deploy Probe</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M402.html">M402: Stow Probe</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M404.html">M404: Set Filament Diameter</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M405.html">
+                      M405: Filament Width Sensor On
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M406.html">
+                      M406: Filament Width Sensor Off
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M407.html">M407: Filament Width</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M410.html">M410: Quickstop</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M420.html">M420: Bed Leveling State</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M421.html">M421: Set Mesh Value</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M428.html">M428: Home Offsets Here</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M500.html">M500: Save Settings</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M501.html">M501: Restore Settings</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M502.html">M502: Factory Reset</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M503.html">M503: Report Settings</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M504.html">
+                      M504: Validate EEPROM contents
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M524.html">M524: Abort SD print</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M540.html">M540: Endstops Abort SD</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M600.html">M600: Filament Change</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M603.html">
+                      M603: Configure Filament Change
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M605.html">M605: Dual Nozzle Mode</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M665.html">M665: Delta Configuration</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M665-scara.html">M665: SCARA Configuration</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M666.html">
+                      M666: Set Delta endstop adjustments
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M666-dual.html">
+                      M666: Set dual endstop offsets
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M851.html">M851: Z Probe Offset</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M852.html">M852: Bed Skew Compensation</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M900.html">M900: Linear Advance Factor</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M906.html">M906: TMC Motor Current</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M907.html">M907: Set Motor Current</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M908.html">M908: Set Trimpot Pins</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M909.html">M909: DAC Print Values</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M910.html">M910: Commit DAC to EEPROM</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M911.html">
+                      M911: TMC OT Pre-Warn Condition
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M912.html">M912: Clear TMC OT Pre-Warn</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M913.html">
+                      M913: Set Hybrid Threshold Speed
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M914.html">M914: TMC Bump Sensitivity</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M915.html">M915: TMC Z axis calibration</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M928.html">M928: Start SD Logging</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/gcode/M999.html">M999: STOP Restart</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li class="dropdown-submenu hardware">
+                <a
+                  href="#"
+                  class="dropdown-toggle"
+                  data-toggle="dropdown"
+                >Hardware</a>
+
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="/meta/hardware/">All documents</a>
+                  </li>
+
+                  <li class="divider"></li>
+
+                  <li>
+                    <a href="/docs/hardware/boards.html">Boards</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/hardware/endstops.html">Endstops</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/hardware/tmc_drivers.html">Trinamic drivers</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li class="divider"></li>
+
+              <li>
+                <a href="/meta/needs-review/">Documentation Needing Review</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+        <ul class="nav navbar-nav navbar-right visible-lg-block">
+          <li>
+            <a
+              href="https://github.com/MarlinFirmware/MarlinDocumentation/edit/master/_tools/lin_advance/k-factor.html"
+              data-proofer-ignore="data-proofer-ignore"
+            >
+              <i
+                class="fa fa-pencil-square-o"
+                aria-hidden="true"
+              ></i>
+
+              <span>Improve this page</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <script
+    language="JavaScript"
+    type="text/javascript"
+    src="/assets/javascript/jquery-2.2.1.min.js"
+  ></script>
+
+  <script
+    language="JavaScript"
+    type="text/javascript"
+    src="/assets/javascript/jquery-ui.min.js"
+  ></script>
+
+  <script
+    language="JavaScript"
+    type="text/javascript"
+    src="./FileSaver.min.js"
+  ></script>
+
+  <script
+    language="JavaScript"
+    type="text/javascript"
+    src="./k-factor.js"
+  ></script>
+
+  <div
+    class="container"
+    role="main"
+  >
+    <div class="row">
+      <div
+        class="calibpat"
+        id="calibpat"
+      >
+        <h1>K-factor Calibration Pattern</h1>
+
+        <div class="row alert alert-info custom-alert">
+          <div class="col-lg-1 col-md-2 visible-lg-block visible-md-block custom-alert-icon">
+            <i
+              class="fa fa-info-circle fa-4x"
+              aria-hidden="true"
+            ></i>
+          </div>
+
+          <div class="col-lg-11 col-md-10 custom-alert-text">
+            <p>
+              There are two versions of Linear Advance. Linear Advance 1.0 is in Marlin 1.1.8 and earlier. Marlin 1.1.9 and up have Linear Advance 1.5.
+            </p>
+          </div>
+        </div>
+
+        <p>
+          The Javascript below generates G-code to calibrate the Linear Advance K-factor. The default values apply to typical PLA with a 0.4mm nozzle.
+        </p>
+
+        <p>
+          Press the
+
+          <code class="highlighter-rouge">Generate G-code</code>
+
+          button then use
+
+          <code class="highlighter-rouge">Download as file</code>
+
+          to save the result.
+        </p>
+
+        <table>
+          <tbody>
+            <tr>
+              <td
+                colspan="3"
+                class="tdHead"
+              >
+                <h3>Settings</h3>
+              </td>
+
+              <td class="tdHead">
+                <h3>G-code</h3>
+              </td>
+            </tr>
+
+            <tr>
+              <td
+                colspan="3"
+                class="tdSection"
+              >
+                <h4>Printer:</h4>
+              </td>
+
+              <td
+                rowspan="45"
+                class="txtareatd"
+              >
+                <textarea
+                  name="textarea"
+                  id="textarea"
+                ></textarea>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="FIL_DIA">Filament Diameter:</label>
+              </td>
+
+              <td>
+                <input
+                  name="FIL_DIA"
+                  type="number"
+                  id="FIL_DIA"
+                  step="any"
+                  value="1.75"
+                ></input>
+              </td>
+
+              <td>
+                Diameter of the used filament (mm)
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="NOZ_DIA">Nozzle Diameter:</label>
+              </td>
+
+              <td>
+                <input
+                  name="NOZ_DIA"
+                  type="number"
+                  id="NOZ_DIA"
+                  step="any"
+                  value="0.4"
+                ></input>
+              </td>
+
+              <td>Diameter of the nozzle (mm)</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="NOZZLE_TEMP">Nozzle Temperature:</label>
+              </td>
+
+              <td>
+                <input
+                  name="NOZZLE_TEMP"
+                  type="number"
+                  id="NOZZLE_TEMP"
+                  step="any"
+                  value="205"
+                ></input>
+              </td>
+
+              <td>Nozzle Temperature (°C)</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="BED_TEMP">Bed Temperature:</label>
+              </td>
+
+              <td>
+                <input
+                  name="BED_TEMP"
+                  type="number"
+                  id="BED_TEMP"
+                  step="any"
+                  value="60"
+                ></input>
+              </td>
+
+              <td>Bed Temperature (°C)</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="RETRACTION">Retraction Distance:</label>
+              </td>
+
+              <td>
+                <input
+                  name="RETRACTION"
+                  type="number"
+                  id="RETRACTION"
+                  step="any"
+                  value="1"
+                ></input>
+              </td>
+
+              <td>Retraction distance (mm)</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="LAYER_HEIGHT">Layer Height:</label>
+              </td>
+
+              <td>
+                <input
+                  name="LAYER_HEIGHT"
+                  type="number"
+                  id="LAYER_HEIGHT"
+                  step="0.1"
+                  value="0.2"
+                ></input>
+              </td>
+
+              <td>Layer Height (mm)</td>
+            </tr>
+
+            <tr>
+              <td
+                colspan="3"
+                class="tdSection"
+              >
+                <h4>Print Bed:</h4>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="SHAPE_BED">Bed Shape:</label>
+              </td>
+
+              <td>
+                <select
+                  name="SHAPE_BED"
+                  id="SHAPE_BED"
+                >
+                  <option value="Rect">Rectangular</option>
+
+                  <option value="Round">Round</option>
+                </select>
+              </td>
+
+              <td>
+                Rectangular or round bed. Round beds will activate Origin Bed Center
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="BEDSIZE_X">Bed Size X:</label>
+              </td>
+
+              <td>
+                <input
+                  name="BEDSIZE_X"
+                  type="number"
+                  id="BEDSIZE_X"
+                  step="any"
+                  value="200"
+                ></input>
+              </td>
+
+              <td id="shape">Size (mm) of the bed in X</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="BEDSIZE_Y">Bed Size Y:</label>
+              </td>
+
+              <td>
+                <input
+                  name="BEDSIZE_Y"
+                  type="number"
+                  id="BEDSIZE_Y"
+                  step="any"
+                  value="200"
+                ></input>
+              </td>
+
+              <td>Size (mm) of the bed in Y</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="CENTER_NULL">Origin Bed Center:</label>
+              </td>
+
+              <td>
+                <input
+                  name="CENTER_NULL"
+                  type="checkbox"
+                  id="CENTER_NULL"
+                ></input>
+              </td>
+
+              <td>
+                Set the origin position (X0 Y0) to bed center instead of front-left corner
+              </td>
+            </tr>
+
+            <tr>
+              <td
+                colspan="3"
+                class="tdSection"
+              >
+                <h4>Speed:</h4>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="MM_S">Use mm/s:</label>
+              </td>
+
+              <td>
+                <input
+                  name="MM_S"
+                  type="checkbox"
+                  id="MM_S"
+                  checked="checked"
+                ></input>
+              </td>
+
+              <td>Use mm/s instead of mm/min</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="SLOW_SPEED">Slow Printing Speed:</label>
+              </td>
+
+              <td>
+                <input
+                  name="SLOW_SPEED"
+                  type="number"
+                  id="SLOW_SPEED"
+                  step="any"
+                  value="20"
+                ></input>
+              </td>
+
+              <td>Slow printing speed</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="FAST_SPEED">Fast Printing Speed:</label>
+              </td>
+
+              <td>
+                <input
+                  name="FAST_SPEED"
+                  type="number"
+                  id="FAST_SPEED"
+                  step="any"
+                  value="70"
+                ></input>
+              </td>
+
+              <td>
+                Fast printing speed. This should differ noticeably from Slow Speed
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="MOVE_SPEED">Movement Speed:</label>
+              </td>
+
+              <td>
+                <input
+                  name="MOVE_SPEED"
+                  type="number"
+                  id="MOVE_SPEED"
+                  step="any"
+                  value="120"
+                ></input>
+              </td>
+
+              <td>Movement speed</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="RETRACT_SPEED">Retract Speed:</label>
+              </td>
+
+              <td>
+                <input
+                  name="RETRACT_SPEED"
+                  type="number"
+                  id="RETRACT_SPEED"
+                  step="any"
+                  value="30"
+                ></input>
+              </td>
+
+              <td>Retract Speed of the extruder</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="PRINT_ACCL">Acceleration:</label>
+              </td>
+
+              <td>
+                <input
+                  name="PRINT_ACCL"
+                  type="number"
+                  id="PRINT_ACCL"
+                  step="any"
+                  value="500"
+                ></input>
+              </td>
+
+              <td>
+                Set printing acceleration (mm/s^2)
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="X_JERK">Jerk X:</label>
+              </td>
+
+              <td>
+                <input
+                  name="X_JERK"
+                  type="number"
+                  id="X_JERK"
+                  step="1"
+                  value="-1"
+                ></input>
+              </td>
+
+              <td>
+                Set the Jerk for the X-axis. -1 to use firmware default
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="Y_JERK">Jerk Y:</label>
+              </td>
+
+              <td>
+                <input
+                  name="Y_JERK"
+                  type="number"
+                  id="Y_JERK"
+                  step="1"
+                  value="-1"
+                ></input>
+              </td>
+
+              <td>
+                Set the Jerk for the Y-axis. -1 to use firmware default
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="Z_JERK">Jerk Z:</label>
+              </td>
+
+              <td>
+                <input
+                  name="Z_JERK"
+                  type="number"
+                  id="Z_JERK"
+                  step="1"
+                  value="-1"
+                ></input>
+              </td>
+
+              <td>
+                Set the Jerk for the Z-axis. -1 to use firmware default
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="E_JERK">Jerk E:</label>
+              </td>
+
+              <td>
+                <input
+                  name="E_JERK"
+                  type="number"
+                  id="E_JERK"
+                  step="1"
+                  value="-1"
+                ></input>
+              </td>
+
+              <td>
+                Set the Jerk for the Extruder. -1 to use firmware default
+              </td>
+            </tr>
+
+            <tr>
+              <td
+                colspan="3"
+                class="tdSection"
+              >
+                <h4>Pattern:</h4>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="LIN_VERSION">Lin Advance Version:</label>
+              </td>
+
+              <td>
+                <select
+                  name="LIN_VERSION"
+                  id="LIN_VERSION"
+                >
+                  <option value="1.0">1.0</option>
+
+                  <option
+                    value="1.5"
+                    selected="selected"
+                  >1.5</option>
+                </select>
+              </td>
+
+              <td>
+                Select version 1.0 for Marlin 1.1.8 and earlier. Select 1.5 for Marlin 1.1.9 / 2.0 and up
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="TYPE_PATTERN">Pattern Type:</label>
+              </td>
+
+              <td>
+                <select
+                  name="TYPE_PATTERN"
+                  id="TYPE_PATTERN"
+                >
+                  <option value="std">Standard</option>
+
+                  <option value="alt">Alternate</option>
+                </select>
+              </td>
+
+              <td>
+                Select standard or alternate pattern
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="K_START">Starting Value for K:</label>
+              </td>
+
+              <td>
+                <input
+                  name="K_START"
+                  type="number"
+                  id="K_START"
+                  step="any"
+                  value="0"
+                  onblur="validateInput()"
+                ></input>
+              </td>
+
+              <td id="start_factor">
+                Starting value for the K-factor. Usually 0 but for bowden setups you might want to start higher, e.g. 30
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="K_END">Ending Value for K:</label>
+              </td>
+
+              <td>
+                <input
+                  name="K_END"
+                  type="number"
+                  id="K_END"
+                  step="any"
+                  value="2"
+                  onblur="validateInput()"
+                ></input>
+              </td>
+
+              <td id="end_factor">
+                Ending value of the K-factor. Bowden setups may be higher than 100
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="K_STEP">K-factor Stepping:</label>
+              </td>
+
+              <td>
+                <input
+                  name="K_STEP"
+                  type="number"
+                  id="K_STEP"
+                  step="any"
+                  value="0.2"
+                  onblur="validateInput()"
+                ></input>
+              </td>
+
+              <td id="step_factor">
+                Stepping of the K-factor in the test pattern. Needs to be an exact divisor of the K-factor Range (End - Start)
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="SLOW_LENGTH">Slow Speed Length:</label>
+              </td>
+
+              <td>
+                <input
+                  name="SLOW_LENGTH"
+                  type="number"
+                  id="SLOW_LENGTH"
+                  step="1"
+                  value="20"
+                  onblur="validateInput()"
+                ></input>
+              </td>
+
+              <td>
+                Length of the Slow Speed test-line (mm)
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="FAST_LENGTH">Fast Speed Length:</label>
+              </td>
+
+              <td>
+                <input
+                  name="FAST_LENGTH"
+                  type="number"
+                  id="FAST_LENGTH"
+                  step="1"
+                  value="40"
+                  onblur="validateInput()"
+                ></input>
+              </td>
+
+              <td>
+                Length of the Fast Speed test-line (mm)
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="SPACE_LINE">Test Line Spacing:</label>
+              </td>
+
+              <td>
+                <input
+                  name="SPACE_LINE"
+                  type="number"
+                  id="SPACE_LINE"
+                  step="0.1"
+                  value="5"
+                  onblur="validateInput()"
+                ></input>
+              </td>
+
+              <td>
+                Distance between the test lines. This will impact print size
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="FRAME">Print Anchor Frame:</label>
+              </td>
+
+              <td>
+                <input
+                  name="FRAME"
+                  type="checkbox"
+                  id="FRAME"
+                ></input>
+              </td>
+
+              <td>
+                Adds a frame around the start and end points of the test lines. May improve adhesion
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="DIR_PRINT">Printing Direction:</label>
+              </td>
+
+              <td>
+                <select
+                  name="DIR_PRINT"
+                  id="DIR_PRINT"
+                  onchange="validateInput()"
+                >
+                  <option
+                    value="0"
+                    selected="selected"
+                  >Left to Right (0°)</option>
+
+                  <option value="45">45°</option>
+
+                  <option value="90">Front to Back (90°)</option>
+
+                  <option value="135">135°</option>
+
+                  <option value="180">Right to Left (180°)</option>
+
+                  <option value="225">225°</option>
+
+                  <option value="270">Back to Front (270°)</option>
+
+                  <option value="315">315°</option>
+                </select>
+              </td>
+
+              <td>
+                Rotates the print in 45° steps
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="LINE_NO">Line Numbering:</label>
+              </td>
+
+              <td>
+                <input
+                  name="LINE_NO"
+                  type="checkbox"
+                  id="LINE_NO"
+                  checked="checked"
+                ></input>
+              </td>
+
+              <td>
+                Prints the K-value besides every second test line
+              </td>
+            </tr>
+
+            <tr>
+              <td
+                colspan="3"
+                class="tdSection"
+              >
+                <h4>Advanced:</h4>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="NOZ_LIN_R">Nozzle Line Ratio:</label>
+              </td>
+
+              <td>
+                <input
+                  name="NOZ_LIN_R"
+                  type="number"
+                  id="NOZ_LIN_R"
+                  step="0.1"
+                  value="1.2"
+                ></input>
+              </td>
+
+              <td>
+                Ratio between extruded line width and nozzle diameter. Should be between 1.05 and 1.2
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="OFFSET_Z">Z-Offset:</label>
+              </td>
+
+              <td>
+                <input
+                  name="OFFSET_Z"
+                  type="number"
+                  id="OFFSET_Z"
+                  step="any"
+                  value="0"
+                ></input>
+              </td>
+
+              <td>
+                Offset the Z-axis for manual Layer adjustment
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="USE_BL">Use Bed Leveling:</label>
+              </td>
+
+              <td>
+                  <select
+                  name="SELECT_BED_LEVELING"
+                  id="SELECT_BED_LEVELING"
+                  onchange="validateInput()"
+                >
+                  <option
+                    value="0"
+                    selected="selected"
+                  >No</option>
+                  <option value="G29">Level bed (G29)</option>
+                  <option value="M420 L0 S1;">Load UBL mesh 0</option>
+                  <option value="M420 L1 S1;">Load UBL mesh 1</option>
+                  <option value="M420 L2 S1;">Load UBL mesh 2</option>
+                  <option value="M420 L3 S1;">Load UBL mesh 3</option>
+                </select>
+              </td>
+
+              <td>
+                Level bed or load a saved mesh (i.e. for UBL) before printing. Bed leveling has to be activated in Configuration.h! Loading a mesh requires UBL to be activated! 
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="USE_FWR">Use FW Retract</label>
+              </td>
+
+              <td>
+                <input
+                  type="checkbox"
+                  name="USE_FWR"
+                  id="USE_FWR"
+                ></input>
+              </td>
+
+              <td>
+                Use Firmware Retract. Needs to be activated in Marlin
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="EXTRUSION_MULT">Extrusion Multiplier:</label>
+              </td>
+
+              <td>
+                <input
+                  name="EXTRUSION_MULT"
+                  type="number"
+                  id="EXTRUSION_MULT"
+                  step="0.1"
+                  value="1.0"
+                ></input>
+              </td>
+
+              <td>Usually 1.0</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="PRIME">Prime Nozzle:</label>
+              </td>
+
+              <td>
+                <input
+                  name="PRIME"
+                  type="checkbox"
+                  id="PRIME"
+                  checked="checked"
+                ></input>
+              </td>
+
+              <td>
+                Prime the nozzle before starting the test pattern
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="PRIME_EXT">Prime Extrusion Multiplier:</label>
+              </td>
+
+              <td>
+                <input
+                  name="PRIME_EXT"
+                  type="number"
+                  id="PRIME_EXT"
+                  step="0.1"
+                  value="2.5"
+                ></input>
+              </td>
+
+              <td>
+                The default of 2.5 results in roughly 1mm of filament for 10mm line length
+              </td>
+            </tr>
+
+            <tr>
+              <td height="24">
+                <label for="PRIME_SPEED">Prime Printing Speed:</label>
+              </td>
+
+              <td>
+                <input
+                  name="PRIME_SPEED"
+                  type="number"
+                  id="PRIME_SPEED"
+                  step="any"
+                  value="30"
+                ></input>
+              </td>
+
+              <td>Speed of the prime move</td>
+            </tr>
+
+            <tr>
+              <td>
+                <label for="DWELL_PRIME">Dwell Time:</label>
+              </td>
+
+              <td>
+                <input
+                  name="DWELL_PRIME"
+                  type="number"
+                  id="DWELL_PRIME"
+                  step="0.1"
+                  value="2"
+                ></input>
+              </td>
+
+              <td>
+                Inserts a pause of x seconds before starting the test pattern to bleed off any residual nozzle pressure
+              </td>
+            </tr>
+
+            <tr class="calibpat2">
+              <td colspan="3">
+                <p>
+                  <input
+                    name="button"
+                    type="button"
+                    id="button"
+                    onclick="genGcode()"
+                    value="Generate G-code"
+                  ></input>
+
+                  <input
+                    name="button3"
+                    type="button"
+                    id="button3"
+                    onclick="setLocalStorage()"
+                    value="Save as default"
+                  ></input>
+                </p>
+
+                <p
+                  id="warning1"
+                  style="display: none;"
+                >warning</p>
+
+                <p
+                  id="warning2"
+                  style="display: none;"
+                >warning</p>
+              </td>
+
+              <td>
+                <p>
+                  <input
+                    name="button2"
+                    type="button"
+                    id="button2"
+                    onclick="saveTextAsFile()"
+                    value="Download as file"
+                  ></input>
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Notes on the settings:</h3>
+
+        <ul>
+          <li>
+            <code class="highlighter-rouge">Fast Printing Speed</code>
+
+            and
+
+            <code class="highlighter-rouge">Slow Printing Speed</code>
+
+            should be significantly different or the K-factor effect will barely be visible.
+          </li>
+
+          <li>
+            <code class="highlighter-rouge">Use Bed Leveling</code>
+
+            requires a probe.
+          </li>
+
+          <li>
+            For round beds the option
+
+            <code class="highlighter-rouge">Origin Bed Center</code>
+
+            is automatically activated.
+          </li>
+
+          <li>
+            The overall width (X-direction) of the print depends on the
+
+            <code class="highlighter-rouge">Fast Speed Length</code>
+
+            and
+
+            <code class="highlighter-rouge">Slow Speed Length</code>
+
+            settings plus 5mm for the priming line. The length (Y-direction) depends on the K-factor Settings and
+
+            <code class="highlighter-rouge">Line Spacing</code>
+
+            .
+          </li>
+
+          <li>
+            The script checks to make sure the print fits on the bed. Verify it using a host software like
+
+            <a
+              href="http://www.pronterface.com/"
+              target="new"
+            >Printrun</a>
+
+            or
+
+            <a
+              href="https://www.repetier.com/"
+              target="new"
+            >Repetier Host</a>
+
+            .
+          </li>
+
+          <li>
+            <code class="highlighter-rouge">Start</code>
+
+            and
+
+            <code class="highlighter-rouge">End Value</code>
+
+            for the K-factor determines the range that the test pattern will cover. For example a
+
+            <code class="highlighter-rouge">Start Value</code>
+
+            of 50 and an
+
+            <code class="highlighter-rouge">End Value</code>
+
+            of 150 will test a range of 100.
+          </li>
+
+          <li>
+            The
+
+            <code class="highlighter-rouge">K-factor Stepping</code>
+
+            determines how many test lines are printed for the above range. For example, a Stepping of 10 and a range of 100 results in 10 test lines. A stepping of 3 would not work in this example as 100 cannot be exactly divided by 3. The script will throw an error message if an exact division is not possible. In this case either the range or the stepping needs to be adjusted.
+          </li>
+
+          <li>
+            The
+
+            <code class="highlighter-rouge">Alternate Pattern</code>
+
+            has a second line of
+
+            <code class="highlighter-rouge">Fast Printing Speed</code>
+
+            to test 0 to
+
+            <code class="highlighter-rouge">Fast Printing Speed</code>
+
+            and back to 0 conditions. Best used with an increased
+
+            <code class="highlighter-rouge">Test Line Spacing</code>
+
+            and reduced K-factor range.
+          </li>
+
+          <li>
+            The proper K-factor depends on the filament, nozzle size, nozzle geometry and printing temperature. If any of these values change, the calibration might need to be repeated.
+          </li>
+        </ul>
+
+        <h2>Screen-shots</h2>
+
+        <p>
+          The following screen-shots show some examples of the test patterns
+        </p>
+
+        <ul>
+          <li>
+            Blue Lines are Slow Printing Speeds
+          </li>
+
+          <li>
+            Red Lines are Fast Printing Speed
+          </li>
+
+          <li>
+            Light blue lines are movements
+          </li>
+        </ul>
+
+        <h3>Standard Pattern</h3>
+
+        <p>
+          <img
+            src="/assets/images/features/lin_advance/std_pattern.png"
+            alt="StandardPattern"
+          >
+        </p>
+
+        <br>
+
+        <h3>
+          Alternate Pattern with increased Test Line Spacing
+        </h3>
+
+        <p>
+          <img
+            src="/assets/images/features/lin_advance/alt_pattern.png"
+            alt="AlternatePattern"
+          >
+        </p>
+
+        <br>
+
+        <h3>Standard Pattern with Frame</h3>
+
+        <p>
+          <img
+            src="/assets/images/features/lin_advance/frame_pattern.png"
+            alt="FramePattern"
+          >
+        </p>
+
+        <br>
+
+        <h3>45° rotated Alternate Pattern</h3>
+
+        <p>
+          <img
+            src="/assets/images/features/lin_advance/rot_pattern.png"
+            alt="RotatedPattern"
+          >
+        </p>
+      </div>
+    </div>
+  </div>
+
+  }
+
+  <footer>
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-12">
+          <hr>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-8">
+          <p>
+            Brought to you with
+
+            <i
+              class="fa fa-heart text-danger"
+              aria-hidden="true"
+            ></i>
+
+            lack of
+
+            <i
+              class="fa fa-bed"
+              aria-hidden="true"
+            ></i>
+
+            and lots of
+
+            <i
+              class="fa fa-coffee"
+              aria-hidden="true"
+            ></i>
+
+            .
+
+            <br>
+            The contents of this website are © 2018 under the terms of the
+
+            <a href="http://www.gnu.org/licenses/gpl-3.0.txt">GPLv3</a>
+
+            License.
+          </p>
+        </div>
+
+        <div class="col-lg-4">
+          <div class="pull-right">
+            <a
+              href="#top"
+              data-proofer-ignore="data-proofer-ignore"
+            >
+              Back to top
+
+              <i
+                class="fa fa-level-up"
+                aria-hidden="true"
+              ></i>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
@@ -51,4 +2389,6 @@
 
       ga('require', 'displayfeatures');
       ga('send', 'pageview');
-    </script> </body> </html>
+  </script>
+</body>
+</html>

--- a/tools/lin_advance/k-factor.js
+++ b/tools/lin_advance/k-factor.js
@@ -58,7 +58,7 @@ function genGcode() {
       LINE_SPACING = parseFloat(document.getElementById('SPACE_LINE').value),
       USE_FRAME = document.getElementById('FRAME').checked,
       USE_PRIME = document.getElementById('PRIME').checked,
-      USE_BL = document.getElementById('USE_BL').checked,
+      BED_LEVELING = SELECT_BED_LEVELING.options[SELECT_BED_LEVELING.selectedIndex].value,
       USE_MMS = document.getElementById('MM_S').checked,
       USE_FWR = document.getElementById('USE_FWR').checked,
       EXT_MULT_PRIME = parseFloat(document.getElementById('PRIME_EXT').value),
@@ -170,7 +170,7 @@ function genGcode() {
                   ';\n' +
                   '; Settings Advance:\n' +
                   '; Nozzle / Line Ratio = ' + NOZZLE_LINE_RATIO + '\n' +
-                  '; Use BL = ' + (USE_BL ? 'true' : 'false') + '\n' +
+                  '; Bed leveling = ' + BED_LEVELING + '\n' +
                   '; Use FWRETRACT = ' + (USE_FWR ? 'true' : 'false') + '\n' +
                   '; Extrusion Multiplier = ' + EXT_MULT + '\n' +
                   '; Prime Nozzle = ' + (USE_PRIME ? 'true' : 'false') + '\n' +
@@ -180,11 +180,11 @@ function genGcode() {
                   ';\n' +
                   '; prepare printing\n' +
                   ';\n' +
-                  'G28 ; home all axes\n' +
-                  'M190 S' + BED_TEMP + ' ; set and wait for bed temp\n' +
-                  'M104 S' + NOZZLE_TEMP + ' ; set nozzle temp and continue\n' +
-                  (USE_BL ? 'G29 ; execute bed automatic leveling compensation\n': '') +
+                  'M104 S' + NOZZLE_TEMP + ' ; set nozzle temperature but do not wait\n' +
+                  'M190 S' + BED_TEMP + ' ; set bed temperature and wait\n' +
                   'M109 S' + NOZZLE_TEMP + ' ; block waiting for nozzle temp\n' +
+                  'G28 ; home all axes with heated bed\n' +
+                  (BED_LEVELING != "0" ? BED_LEVELING + '; Activate bed leveling compensation\n' : '') +
                   'G21 ; set units to millimeters\n' +
                   'M204 P' + ACCELERATION + ' ; set acceleration\n' +
                   (JERK_X !== -1 ? 'M205 X' + JERK_X + ' ; set X jerk\n' : '') +
@@ -637,7 +637,6 @@ function setLocalStorage() {
       LENGTH_SLOW = parseFloat(document.getElementById('SLOW_LENGTH').value),
       LENGTH_FAST = parseFloat(document.getElementById('FAST_LENGTH').value),
       Z_OFFSET = parseFloat(document.getElementById('OFFSET_Z').value),
-      USE_BL = document.getElementById('USE_BL').checked,
       USE_FWR = document.getElementById('USE_FWR').checked,
       USE_MMS = document.getElementById('MM_S').checked,
       USE_LINENO = document.getElementById('LINE_NO').checked;
@@ -680,7 +679,6 @@ function setLocalStorage() {
     'LENGTH_SLOW': LENGTH_SLOW,
     'LENGTH_FAST': LENGTH_FAST,
     'Z_OFFSET': Z_OFFSET,
-    'USE_BL': USE_BL,
     'USE_FWR': USE_FWR,
     'USE_MMS': USE_MMS,
     'USE_LINENO': USE_LINENO
@@ -748,7 +746,6 @@ $(window).load(function() {
       $('#SLOW_LENGTH').val(settings['LENGTH_SLOW']);
       $('#FAST_LENGTH').val(settings['LENGTH_FAST']);
       $('#OFFSET_Z').val(settings['Z_OFFSET']);
-      $('#USE_BL').prop('checked', settings['USE_BL']);
       $('#USE_FWR').prop('checked', settings['USE_FWR']);
       $('#MM_S').prop('checked', settings['USE_MMS']);
       $('#LINE_NO').prop('checked', settings['USE_LINENO']);


### PR DESCRIPTION
With my version of the K-factor generator 

1) the bed and the nozzle is heated up before homing. This compensates thermal expansion when using a sensor (BLTouch, Piezo...) instead of a fixed Z endstop.

2) Instead of always calling G29 you can now chose between "Don't use leveling", "Execute G29" and "load a saved UBL mesh between 0 and 3".