### PR TITLE
Fix `G012.md` long description parsing

### DIFF
--- a/_gcode/G012.md
+++ b/_gcode/G012.md
@@ -11,8 +11,8 @@ group: nozzle
 codes:
   - G12
 
-long:
-  - Start the nozzle cleaning process. Three types of cleaning patterns are supported: straight strokes, zigzags and circles. This feature requires a dedicated cleaning area on or outside the bed, but within reach of the nozzle. The patten may be repeated as many times as desired.
+long: |
+  Start the nozzle cleaning process. Three types of cleaning patterns are supported: straight strokes, zigzags and circles. This feature requires a dedicated cleaning area on or outside the bed, but within reach of the nozzle. The patten may be repeated as many times as desired.
 
 notes:
   - Default behavior is defined by `NOZZLE_CLEAN_STROKES`, `NOZZLE_CLEAN_START_POINT`, `NOZZLE_CLEAN_END_POINT`, `NOZZLE_CLEAN_TRIANGLES`, `NOZZLE_CLEAN_CIRCLE_MIDDLE`, `NOZZLE_CLEAN_CIRCLE_RADIUS` and `NOZZLE_CLEAN_GOBACK`.


### PR DESCRIPTION
## Issue reason:

`:` in `long` text isn't escaped and sentence is parsed as `key-value` instead of string scalar.

## Before:
![](https://i.imgur.com/gJV61eQ.png)

## Now:
![](https://i.imgur.com/OEX01jS.png)