### PR TITLE
G29 (manual) S3 example incorrect

### DIFF
--- a/_gcode/G029-mbl.md
+++ b/_gcode/G029-mbl.md
@@ -106,7 +106,7 @@ examples:
     pre: 'Modify some mesh points and view the new mesh:'
     code:
       - |
-        > S3 X3 3 Z0.042
+        > S3 X3 Y3 Z0.042
         > S3 X2 Y2 Z-0.666
         > S0
         Num X,Y: 3,3

--- a/_gcode/G029-mbl.md
+++ b/_gcode/G029-mbl.md
@@ -106,8 +106,8 @@ examples:
     pre: 'Modify some mesh points and view the new mesh:'
     code:
       - |
-        > S3 X2 Y2 Z0.042
-        > S3 X1 Y1 Z-0.666
+        > S3 X3 3 Z0.042
+        > S3 X2 Y2 Z-0.666
         > S0
         Num X,Y: 3,3
         Z offset: 0


### PR DESCRIPTION
The code explicitly translates G29 S3 X and Y indices from 1..GRID_MAX_POINTS_X/Y to 0..MAX-1 for use in the mbl array, so the example is incorrect.
Trivial change to align the example with the code behaviour.