### PR TITLE
Fix missing parameter on M28 documentation page.

### DIFF
--- a/_gcode/M028.md
+++ b/_gcode/M028.md
@@ -21,9 +21,9 @@ parameters:
   -
     tag: filename
     optional: false
-    description: File name to write to
+    description: File name to write
     
-examples:
+example:
   -
     pre: Start writing to file.txt
     code: M28 file.txt

--- a/_gcode/M028.md
+++ b/_gcode/M028.md
@@ -18,8 +18,15 @@ notes:
   - To write commands to a file while also printing, use [`M928`](/docs/gcode/M928.html)
 
 parameters:
-
+  -
+    tag: filename
+    optional: false
+    description: File name to write to
+    
 examples:
-
+  -
+    pre: Start writing to file.txt
+    code: M28 file.txt
+    
 ---
 


### PR DESCRIPTION
Observing Marlin_main.cpp, this command has a mandatory argument: the file name.