### PR TITLE
Follow up fixes to G425/M425 documentation

### DIFF
--- a/_gcode/G000-G001.md
+++ b/_gcode/G000-G001.md
@@ -1,5 +1,5 @@
 ---
-tag: g00
+tag: g000
 title: Linear Move
 brief: Add a straight line movement to the planner
 author: thinkyhead

--- a/_gcode/G002-G003.md
+++ b/_gcode/G002-G003.md
@@ -1,5 +1,5 @@
 ---
-tag: g02
+tag: g002
 title: Controlled Arc Move
 brief: Add an arc movement to the planner
 author: thinkyhead
@@ -17,14 +17,14 @@ long: |
 
       This command has two forms:
       #### I J Form
-      
+
        - `I` specifies an X offset. `J` specifies a Y offset.
        - At least one of the `I` `J` parameters is required.
        - `X` and `Y` can be omitted to do a complete circle.
        - The given `X` `Y` is not error-checked.
          The arc ends based on the angle of the destination.
        - Mixing `I` or `J` with `R` will throw an error.
-      
+
       #### R Form
        - `R` specifies the radius. `X` or `Y` is required.
        - Omitting both `X` and `Y` will throw an error.

--- a/_gcode/G004.md
+++ b/_gcode/G004.md
@@ -1,5 +1,5 @@
 ---
-tag: g04
+tag: g004
 title: Dwell
 brief: Pause the planner
 author: thinkyhead

--- a/_gcode/G005.md
+++ b/_gcode/G005.md
@@ -1,5 +1,5 @@
 ---
-tag: g05
+tag: g005
 title: Bézier cubic spline
 brief: Cubic B-spline with XYZE destination and IJPQ offsets
 author: thinkyhead

--- a/_gcode/G010.md
+++ b/_gcode/G010.md
@@ -1,5 +1,5 @@
 ---
-tag: g10
+tag: g010
 title: Retract
 brief: Retract the filament
 author: thinkyhead
@@ -12,7 +12,7 @@ group: planner
 codes:
   - G10
 
-long: 
+long:
   - Retract the filament according to settings of [`M207`](/docs/gcode/M207.html).
   - Firmware retraction allows you to tune retraction at the machine level and can significantly reduce the size of G-code files.
   - Multiple consecutive `G10` or `G10 S1` commands without a corresponding `G11` or `G11 S1` will be ignored.

--- a/_gcode/G011.md
+++ b/_gcode/G011.md
@@ -1,5 +1,5 @@
 ---
-tag: g11
+tag: g011
 title: Recover
 brief: Recover the filament with firmware-based retract.
 author: thinkyhead

--- a/_gcode/G012.md
+++ b/_gcode/G012.md
@@ -1,5 +1,5 @@
 ---
-tag: g12
+tag: g012
 title: Clean the Nozzle
 brief: Perform the nozzle cleaning procedure.
 

--- a/_gcode/G020.md
+++ b/_gcode/G020.md
@@ -1,5 +1,5 @@
 ---
-tag: g20
+tag: g020
 title: Inch Units
 brief: Set Units to Inches.
 author: thinkyhead

--- a/_gcode/G021.md
+++ b/_gcode/G021.md
@@ -1,5 +1,5 @@
 ---
-tag: g21
+tag: g021
 title: Millimeter Units
 brief: Set Units to Millimeters.
 author: thinkyhead

--- a/_gcode/G026.md
+++ b/_gcode/G026.md
@@ -1,5 +1,5 @@
 ---
-tag: g26
+tag: g026
 title: Mesh Validation Pattern
 brief: Test the mesh and adjust.
 

--- a/_gcode/G027.md
+++ b/_gcode/G027.md
@@ -1,5 +1,5 @@
 ---
-tag: g27
+tag: g027
 title: Park toolhead
 brief: Park the toolhead
 

--- a/_gcode/G028.md
+++ b/_gcode/G028.md
@@ -1,5 +1,5 @@
 ---
-tag: g28
+tag: g028
 title: Auto Home
 brief: Auto home one or more axes.
 author: thinkyhead

--- a/_gcode/G029-abl.md
+++ b/_gcode/G029-abl.md
@@ -1,5 +1,5 @@
 ---
-tag: g29b
+tag: g029b
 title: Bed Leveling (Automatic)
 brief: Probe the bed and enable leveling compensation.
 author: thinkyhead
@@ -24,7 +24,7 @@ long:
 
     * For `AUTO_BED_LEVELING_UBL` see [G29 UBL](/docs/gcode/G029-ubl.html) and [G26 Mesh Editing](/docs/gcode/G026.html).
     * For `MESH_BED_LEVELING` see the [G29 MBL](/docs/gcode/G029-mbl.html) page.
-    
+
   - |
     #### Automatic Probing
 
@@ -158,8 +158,8 @@ parameters:
     tag: E
     optional: true
     description: |
-                 - By default G29 will engage the Z probe, test the bed, then disengage. 
-                 - Include "E" to engage/disengage the Z probe for each sample. 
+                 - By default G29 will engage the Z probe, test the bed, then disengage.
+                 - Include "E" to engage/disengage the Z probe for each sample.
                  - There's no extra effect if you have a fixed Z probe. (without `PROBE_MANUALLY`)
     values:
       -

--- a/_gcode/G029-mbl.md
+++ b/_gcode/G029-mbl.md
@@ -1,5 +1,5 @@
 ---
-tag: g29a
+tag: g029a
 title: Bed Leveling (Manual)
 brief: Measure Z heights in a grid, enable leveling compensation
 author: thinkyhead

--- a/_gcode/G029-ubl.md
+++ b/_gcode/G029-ubl.md
@@ -1,5 +1,5 @@
 ---
-tag: g29c
+tag: g029c
 title: Bed Leveling (Unified)
 brief: Probe the bed and enable leveling compensation.
 
@@ -380,7 +380,7 @@ examples:
     code: |
       M502          ; Reset settings to configuration defaults...
       M500          ; ...and Save to EEPROM. Use this on a new install.
-      M501          ; Read back in the saved EEPROM.  
+      M501          ; Read back in the saved EEPROM.
 
       M190 S65      ; Not required, but having the printer at temperature helps accuracy
       M104 S210     ; Not required, but having the printer at temperature helps accuracy

--- a/_gcode/G030.md
+++ b/_gcode/G030.md
@@ -1,5 +1,5 @@
 ---
-tag: g30
+tag: g030
 title: Single Z-Probe
 brief: Probe bed at current XY location
 author: thinkyhead

--- a/_gcode/G031.md
+++ b/_gcode/G031.md
@@ -1,5 +1,5 @@
 ---
-tag: g31
+tag: g031
 title: Dock Sled
 brief: Dock the Z probe sled.
 author: thinkyhead

--- a/_gcode/G032.md
+++ b/_gcode/G032.md
@@ -1,5 +1,5 @@
 ---
-tag: g32
+tag: g032
 title: Undock Sled
 brief: Undock the Z probe sled.
 author: thinkyhead

--- a/_gcode/G033.md
+++ b/_gcode/G033.md
@@ -1,5 +1,5 @@
 ---
-tag: g33
+tag: g033
 title: Delta Auto Calibration
 brief: Calibrate various Delta parameters
 

--- a/_gcode/G038.md
+++ b/_gcode/G038.md
@@ -1,5 +1,5 @@
 ---
-tag: g38
+tag: g038
 title: Probe target
 brief: Probe towards a workpiece and stop on contact.
 author: thinkyhead

--- a/_gcode/G042.md
+++ b/_gcode/G042.md
@@ -1,5 +1,5 @@
 ---
-tag: g42
+tag: g042
 title: Move to mesh coordinate
 brief: Move to a specific point in the leveling mesh
 author: ManuelMcLure

--- a/_gcode/G090.md
+++ b/_gcode/G090.md
@@ -1,5 +1,5 @@
 ---
-tag: g90
+tag: g090
 title: Absolute Positioning
 brief: Use absolute positions.
 author: thinkyhead

--- a/_gcode/G091.md
+++ b/_gcode/G091.md
@@ -1,5 +1,5 @@
 ---
-tag: g91
+tag: g091
 title: Relative Positioning
 brief: Use relative positions.
 author: thinkyhead

--- a/_gcode/G092.md
+++ b/_gcode/G092.md
@@ -1,5 +1,5 @@
 ---
-tag: g92
+tag: g092
 title: Set Position
 brief: Set the current position of one or more axes.
 author: thinkyhead

--- a/_gcode/G425.md
+++ b/_gcode/G425.md
@@ -1,8 +1,8 @@
 ---
-tag: g0425
+tag: g425
 title: Perform auto-calibration
 brief: Uses a calibration cube, washer or bolt for automatic calibration
-author: mteixeira
+author: marcio-ao
 
 experimental: true
 requires: CALIBRATION_GCODE
@@ -18,10 +18,10 @@ long:
 notes:
   - |
     Requires `CALIBRATION_GCODE` and the following parameters:
-    - `CALIBRATION_MEASUREMENT_RESOLUTION` determines the increments taken in mm when performing measurements
+    - `CALIBRATION_MEASUREMENT_RESOLUTION` determines the increments taken in mm when performing measurements.
     - `CALIBRATION_FEEDRATE_SLOW`, `CALIBRATION_FEEDRATE_FAST` and `CALIBRATION_FEEDRATE_TRAVEL` determine the speed of motion during the calibration.
-    - `CALIBRATION_NOZZLE_TIP_HEIGHT` and `CALIBRATION_NOZZLE_OUTER_DIAMETER` refer to the conical part of the nozzle tip
-    - `CALIBRATION_REPORTING` enables `G425 V` for reporting of measurements
+    - `CALIBRATION_NOZZLE_TIP_HEIGHT` and `CALIBRATION_NOZZLE_OUTER_DIAMETER` refer to the conical part of the nozzle tip.
+    - `CALIBRATION_REPORTING` enables `G425 V` for reporting of measurements.
     - `CALIBRATION_OBJECT_CENTER` and `CALIBRATION_OBJECT_DIMENSIONS` define the true location and dimensions of a cube/bolt/washer mounted on the bed.
     - `CALIBRATION_MEASURE_RIGHT`, `CALIBRATION_MEASURE_FRONT`, `CALIBRATION_MEASURE_LEFT` and `CALIBRATION_MEASURE_BACK` define the usable touch points. Comment out any sides which are unreachable by the probe. For best results, all four sides should be reachable.
     - `CALIBRATION_PIN`, `CALIBRATION_PIN_INVERTING`, `CALIBRATION_PIN_PULLDOWN` and `CALIBRATION_PIN_PULLUP` configure the pin used for calibration. For example, if the nozzle is grounded, the calibation cube would be connected to a digital input pin with a pull-up enabled.
@@ -34,7 +34,7 @@ parameters:
   -
     tag: T
     optional: true
-    description: Perform calibration of toolhead only.
+    description: Perform calibration of one toolhead only.
     values:
       -
         tag: index
@@ -54,19 +54,19 @@ parameters:
 
 examples:
   -
-    pre: Check the positional accuracy before calibration (requires `CALIBRATION_REPORTING`)
+    pre: Check the positional accuracy before calibration (requires `CALIBRATION_REPORTING`):
     code:
       - T1                  ; Switch to second nozzle
       - G425 V              ; Showing positional report for T1
       - T0                  ; Switch to second nozzle
       - G425 V              ; Showing positional report for T0
   -
-    pre: Performs automatic calibration.
+    pre: Performs automatic calibration:
     code:
       - G425                ; Perform full calibration sequence
       - M425 F1 S0          ; Enable backlash compensation at 100%
   -
-    pre: Check the positional accuracy after calibration (requires `CALIBRATION_REPORTING`)
+    pre: Check the positional accuracy after calibration (requires `CALIBRATION_REPORTING`):
     code:
       - T1                  ; Switch to second nozzle
       - G425 V              ; Validate by showing report for T1

--- a/_gcode/M425.md
+++ b/_gcode/M425.md
@@ -2,7 +2,7 @@
 tag: m0425
 title: Backlash compensation
 brief: Enable and tune backlash compensation
-author: mteixeira
+author: marcio-ao
 
 experimental: true
 requires: BACKLASH_COMPENSATION,BACKLASH_GCODE
@@ -14,23 +14,23 @@ codes:
 long:
   - Backlash compensation works by adding extra steps to one or more segments whenever a motor reverses direction.
   - By default, steps will be added to the first segment after a direction change, this gives the best dimensional accuracy but may cause marks to appear in the print. Smoothing spreads those extra steps multiple consecutive segments to prevent blemishes in the print, at the expense of dimensional accuracy.
-  - Backlash compensation can be configured at both compile-time and run-time. Enable 'BACKLASH_GCODE' for run-time configuration, which enables `M425` as well as a "Backlash" menu in the LCD.
-  - Backlash can be automatically measured on all axes with [`G425`](/docs/gcode/G425.html) or on Z only with [`G29`](/docs/gcode/G29.html) when `MEASURE_BACKLASH_WHEN_PROBING` is enabled.
+  - Backlash compensation can be configured at either compile-time or run-time. Enable `BACKLASH_GCODE` for run-time configuration, which enables `M425` and adds a "Backlash" menu to the menu.
+  - Backlash can be measured automatically on all axes with [`G425`](/docs/gcode/G425.html) or on Z only with [`G29`](/docs/gcode/G29.html) when `MEASURE_BACKLASH_WHEN_PROBING` is enabled.
 
 notes: |
   Requires `BACKLASH_COMPENSATION`, `BACKLASH_GCODE` and the following parameters:
     - `BACKLASH_DISTANCE_MM` specifies the default backlash on the X, Y and Z axis.
-    - `BACKLASH_CORRECTION` specifies the default backlash correction (0.0 = 0%, 1.0 = 100%)
+    - `BACKLASH_CORRECTION` specifies the default backlash correction (0.0 = none; 1.0 = 100%).
     - `BACKLASH_SMOOTHING_MM` enables backlash smoothing over a specified distance.
     - `BACKLASH_GCODE` enables `M425` for run-time tuning of backlash.
     - `MEASURE_BACKLASH_WHEN_PROBING` turns on Z backlash measurement when probing ([`G29`](/docs/gcode/G29.html)).
-    - Use `BACKLASH_MEASUREMENT_LIMIT`, `BACKLASH_MEASUREMENT_RESOLUTION` and `BACKLASH_MEASUREMENT_FEEDRATE` configure `G29` measurement.
+    - Use `BACKLASH_MEASUREMENT_LIMIT`, `BACKLASH_MEASUREMENT_RESOLUTION` and `BACKLASH_MEASUREMENT_FEEDRATE` to configure `G29` backlash measurement.
 
 parameters:
   -
     tag: F
     optional: true
-    description: Enable or disables backlash correction, or sets an intermediate fade-out (0.0 = none to 1.0 = 100%)
+    description: Enable or disables backlash correction, or sets an intermediate fade-out (0.0 = none; 1.0 = 100%)
     values:
       -
         tag: value
@@ -70,25 +70,25 @@ parameters:
   -
     tag: Z
     optional: true
-    description: When `MEASURE_BACKLASH_WHEN_PROBING` is enabled, copies the measured backlash into the backlash distance.
+    description: When `MEASURE_BACKLASH_WHEN_PROBING` is enabled, loads the measured backlash into the backlash distance parameter
 
 
 examples:
   -
-    pre: Manually configure backlash compensation
+    pre: Manually configure backlash compensation:
     code:
       - M425 X0.1 Y0.2 Z0.3 ; Set backlash to specific values for all axis
       - M425 F1             ; Enable backlash compensation at 100%
   -
-    pre: Use smoothing for best print surface quality
+    pre: Use smoothing for best print surface quality:
     code:
       - M425 F1 S3
   -
-    pre: Use no smoothing for best dimensional accuracy
+    pre: Use no smoothing for best dimensional accuracy:
     code:
       - M425 F1 S0
   -
-    pre: 'Automatically measure X, Y, and Z backlash using `G425`'
+    pre: 'Automatically measure X, Y, and Z backlash using `G425`:'
     code:
       - G425                ; Perform a full calibration
       - M425 F1             ; Use full measured value of backlash on X, Y and Z
@@ -100,7 +100,7 @@ examples:
       - M425 F1 Z           ; Use full measured value of backlash on Z
     post: '`MEASURE_BACKLASH_WHEN_PROBING` measures backlash, but does not update the configured backlash distance. The measured value should be activated by using the `Z` argument without a value. This differs from the behavior of `G425`.'
   -
-    pre: Report the current backlash configuration
+    pre: Report the current backlash configuration:
     code:
       - M425
 ---


### PR DESCRIPTION
- Changed the tags on all G commands to restore proper sorting order in index.
- Fixed incorrect author tag.
- Small changes to text for consistency and to fix rendering issues.