### PR TITLE
Update configuration.md - Wrong Comment

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -2790,7 +2790,7 @@ The default is M600 which requires [ADVANCED_PAUSE_FEATURE](#advance_pause).
 ### LCD Menu
 
 ```cpp
-  // G-code to execute when MMU2 F.I.N.D.A. probe detects filament runout
+  // Add MMU2 controls to the LCD menu
   #define MMU2_MENUS
 ```
 


### PR DESCRIPTION
The comment is a copy paste error from the previous paragraph about filament runout handling. i changed the comment to say something about the LCD menu