### PR TITLE
Add G34 E parameter, to stow probe after each point.

### DIFF
--- a/_gcode/G034.md
+++ b/_gcode/G034.md
@@ -30,6 +30,10 @@ parameters:
     tag: A
     optional: true
     description: Amplification - must be between 0.5 - 2.0
+  -
+    tag: E
+    optional: true
+    description: Stow probe after probing each point.
 
 
 example:


### PR DESCRIPTION
The G34 command supports an E parameter, to store the probe after each point is probed.