### PR TITLE
Fix M422 to show M422

### DIFF
--- a/_gcode/M422.md
+++ b/_gcode/M422.md
@@ -9,7 +9,7 @@ experimental: true
 group: calibration
 
 codes:
-  - G34
+  - M422
 
 long: |
   Set the XY probe position for a given Z Stepper. See [`G34`](/docs/gcode/G034.html) for Z-Stepper automatic alignment.


### PR DESCRIPTION
http://marlinfw.org/docs/gcode/M422.html currently shows G34 in the title and usage.