### PR TITLE
Fix link by removing extra chars

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -1300,7 +1300,7 @@ Example: To have leveling fade out over the first 10mm of layer printing use `M4
 
 #endif
 ```
-When using any of the mesh-based leveling systems (1.1.7) you can activate `G26_MESH_VALIDATION` to print test patterns and fine-tune the mesh. See [`G26` Mesh Validation](/docs/gcode/G026.html) for full details. The [`G26`]`](/docs/gcode/G026.html) command accepts parameters for nozzle size, layer height, etc. The sub-options above specify the default values that will be applied for omitted parameters.
+When using any of the mesh-based leveling systems (1.1.7) you can activate `G26_MESH_VALIDATION` to print test patterns and fine-tune the mesh. See [`G26` Mesh Validation](/docs/gcode/G026.html) for full details. The [`G26`](/docs/gcode/G026.html) command accepts parameters for nozzle size, layer height, etc. The sub-options above specify the default values that will be applied for omitted parameters.
 
 ### Linear / Bilinear Options
 ```cpp


### PR DESCRIPTION
Link was broken due to extra chars.