### PR TITLE
Corrected links in Installing Marlin (CLI) page

### DIFF
--- a/_basics/install_platformio_cli.md
+++ b/_basics/install_platformio_cli.md
@@ -3,11 +3,11 @@ title:        Installing Marlin (CLI)
 description:  Marlin Installation Quick Start Guide, PlatformIO CLI
 
 author: Bob-the-Kuhn
-contrib:
+contrib: ChrisBountalis
 category: [ articles, getting-started ]
 ---
 
-Before reading this article, you should have already read [Installing Marlin with PlatformIO](install_arduino.html).
+Before reading this article, you should have already read [Installing Marlin with PlatformIO](install_platformio.html).
 
 This article documents:
   * Invoking **PlatformIO** from the command line
@@ -25,7 +25,7 @@ NOTE: If a **PlatformIO** plugin/extension has previously been installed then **
 
 ## Get the correct environment for the selected board
 
-This step is the same as in [Installing Marlin with PlatformIO](install_arduino.html).
+This step is the same as in [Installing Marlin with PlatformIO](install_platformio.html).
 
 The PlatformIO environment needed for a motherboard is in the comments for the board in the **pins.h** file. In Marlin 2.0 it's located in  a subdirectory **Marlin/src/pins/pins.h**.
 


### PR DESCRIPTION
Recently I started experimenting with Marlin and I found two small mistakes, I think, in the documentation. So I made a small pr to correct these two links.

However I am not sure whether the links are wrong, or wherever the text was wrong (In this pr I assumed the first).. 

The two links now point to the parent page that just lists the ways of installing platformio .