### PR TITLE
Add description for M204 S legacy option

### DIFF
--- a/_gcode/M204.md
+++ b/_gcode/M204.md
@@ -14,6 +14,7 @@ long: Set the preferred starting acceleration for moves of different types.
 notes:
   - View the current setting with `M503`.
   - If `EEPROM_SETTINGS` is enabled, these are saved with `M500`, loaded with `M501`, and reset with `M502`.
+  - Legacy `M204 S<accel>` is deprecated. Use separate paremeters `M204 P<accel> T<accel>` instead.
 
 parameters:
   -
@@ -40,6 +41,15 @@ parameters:
       -
         tag: accel
         type: float
+  -
+    tag: S
+    optional: true
+    description: Legacy parameter for move acceleration. Set both printing and travel acceleration.
+    values:
+      -
+        tag: accel
+        type: float
+
 
 examples:
 

--- a/_gcode/M204.md
+++ b/_gcode/M204.md
@@ -50,7 +50,6 @@ parameters:
         tag: accel
         type: float
 
-
 examples:
 
 ---


### PR DESCRIPTION
Add M204 S option description and a deprecation note cause this option is still used by some modern slicers.