### PR TITLE
Fix K-value descriptions for Linear Advance tool

### DIFF
--- a/_tools/lin_advance/k-factor.html
+++ b/_tools/lin_advance/k-factor.html
@@ -171,12 +171,12 @@ category:     [ tools ]
           <tr>
             <td><label for="K_START">Starting Value for K:</label></td>
             <td><input name="K_START" id="K_START" step="any" value="0" onblur="validateInput()" /></td>
-            <td id="start_factor">Starting value for the K-factor. Usually 0 but for bowden setups you might want to start higher, e.g. 30</td>
+            <td id="start_factor">Starting value for the K-factor. Usually 0 but for bowden setups you might want to start higher, e.g. 2</td>
           </tr>
           <tr>
             <td><label for="K_END">Ending Value for K:</label></td>
             <td><input name="K_END" id="K_END" step="any" value="2" onblur="validateInput()" /></td>
-            <td id="end_factor">Ending value of the K-factor. Bowden setups may be higher than 100</td>
+            <td id="end_factor">Ending value of the K-factor. Bowden setups may be higher than 2</td>
           </tr>
           <tr>
             <td><label for="K_STEP">K-factor Stepping:</label></td>

--- a/_tools/lin_advance/k-factor.html
+++ b/_tools/lin_advance/k-factor.html
@@ -171,12 +171,12 @@ category:     [ tools ]
           <tr>
             <td><label for="K_START">Starting Value for K:</label></td>
             <td><input name="K_START" id="K_START" step="any" value="0" onblur="validateInput()" /></td>
-            <td id="start_factor">Starting value for the K-factor. Usually 0 but for bowden setups you might want to start higher, e.g. 2</td>
+            <td id="start_factor">Starting value for the K-factor</td>
           </tr>
           <tr>
             <td><label for="K_END">Ending Value for K:</label></td>
             <td><input name="K_END" id="K_END" step="any" value="2" onblur="validateInput()" /></td>
-            <td id="end_factor">Ending value of the K-factor. Bowden setups may be higher than 2</td>
+            <td id="end_factor">Ending value of the K-factor</td>
           </tr>
           <tr>
             <td><label for="K_STEP">K-factor Stepping:</label></td>

--- a/_tools/lin_advance/k-factor.js
+++ b/_tools/lin_advance/k-factor.js
@@ -888,8 +888,8 @@ function toggleVersion() {
     $('#K_START').val('0');
     $('#K_END').val('2');
     $('#K_STEP').val('0.2');
-    $('#start_factor').text('Starting value for the K-factor. Usually 0 but for bowden setups you might want to start higher, e.g. 2');
-    $('#end_factor').text('Ending value of the K-factor. Bowden setups may be higher than 2');
+    $('#start_factor').text('Starting value for the K-factor');
+    $('#end_factor').text('Ending value of the K-factor');
     $('#step_factor').text('Stepping of the K-factor in the test pattern. Needs to be an exact divisor of the K-factor Range (End - Start)');
   } else {
     $('#K_START').attr('step', '1');


### PR DESCRIPTION
The default K value descriptions did not match the default selected version of 1.5, causing undesirable advice.

Even then it's still not correct according to docs that suggest a range of 0.1-2 for bowden and not to start higher than 2. I chose to completely remove the 'Bowden' advice for v1.5, since I don't see how it's useful.