### PR TITLE
Ensure enough width to hold day/night control.

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -495,6 +495,8 @@ summary h3 { display: inline; }
 //   #daynite { margin-top: -23px; }
 // }
 
+.navbar-header { min-width: 153px; }
+
 .navbar-brand { padding: 2px 0 0; }
 
 footer>.container { display: block; clear: both; margin: 1em auto; }


### PR DESCRIPTION
Under Safari, the day/night control would appear on the next line,  causing the head of the content to be obscured by the taller navigation bar. This occurs no matter the width of the window.

No issue under chrome.