### PR TITLE
Add documentation for verbose level 3

### DIFF
--- a/_gcode/G033.md
+++ b/_gcode/G033.md
@@ -81,6 +81,9 @@ parameters:
         tag: 2
         description: Report settings and probe results
       -
+        tag: 3
+        description: Report settings, probe results, and calibration results
+      -
         default: 1
 
 notes:


### PR DESCRIPTION
There is no documentation for verbose level 3.  According to G33.cpp, range of 0-3 is accepted and 3 adds the printing of calibration results.  Also, there is `default: 1` defined for the V parameter, however that isn't shown on the actual documentation site (nothing clearly explicitly states that the default value is 1, other than the example below. Perhaps add some type of text to denote that the default verbose level is 1?