### PR TITLE
Add M400 in finish section

### DIFF
--- a/_tools/lin_advance/k-factor.js
+++ b/_tools/lin_advance/k-factor.js
@@ -300,6 +300,7 @@ function genGcode() {
   k_script += ';\n' +
               '; FINISH\n' +
               ';\n' +
+              'M400 ; finish moving\n' +
               'M104 S0 ; Turn off hotend\n' +
               'M140 S0 ; Turn off bed\n' +
               'G1 Z30 X' + (NULL_CENTER ? 0 : BED_X) + ' Y' + (NULL_CENTER ? 0 : BED_Y) + ' F' + SPEED_MOVE + ' ; Move away from the print\n' +


### PR DESCRIPTION
Fixes the hotend cooling down before the pattern is finished and messing up the calibration pattern

i had issues with bad prints and found issues like https://github.com/MarlinFirmware/Marlin/issues/15603 , https://github.com/MarlinFirmware/Marlin/issues/17649 and more.
this is when i finally understood why my calibration was so difficult, the hotend cooled down before the pattern was finished.

