### PR TITLE
Fix typo in G092.md

### DIFF
--- a/_gcode/G092.md
+++ b/_gcode/G092.md
@@ -69,4 +69,4 @@ examples:
 
 Set the current position to the values specified. In Marlin 1.1.0 and up, the software endstops are adjusted to preserve the physical movement limits. Thus you could use [`G92`](/docs/gcode/G092.html) to set the middle of the bed to 0,0 and then run .gcode that was sliced for a Deltabot.
 
-The [`CNC_COORDINATE_SYSTEMS`](/docs/gcode/G054-G059.html) option enables use of `G92.1` to reset the selcted workspace to native machine space. See [`G54-G59`](/docs/gcode/G054-G059.html) and [`G53'](/docs/gcode/G053.html).
+The [`CNC_COORDINATE_SYSTEMS`](/docs/gcode/G054-G059.html) option enables use of `G92.1` to reset the selected workspace to native machine space. See [`G54-G59`](/docs/gcode/G054-G059.html) and [`G53'](/docs/gcode/G053.html).


### PR DESCRIPTION
Fix a typo: selcted ➔ selected