### PR TITLE
attempt to fix Jekyll CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-_site/
 build/
 .sass-cache
 .jekyll-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-_site/
+_site/*
 !_site/sitemap.xml
-build/
+build/*
 !build/sitemap.xml
 .sass-cache
 .jekyll-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+_site/
+!_site/sitemap.xml
 build/
+!build/sitemap.xml
 .sass-cache
 .jekyll-metadata
 Gemfile.lock

--- a/build/sitemap.xml
+++ b/build/sitemap.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
+    <url>
+        <loc>http://localhost:4000/feeds/feed.json</loc>
+        
+        <lastmod>2020-05-01T07:21:22+00:00</lastmod>
+    </url>
+    <url>
+        <loc>http://localhost:4000/</loc>
+        <lastmod>2020-05-01T07:21:22+00:00</lastmod>
+    </url>
+    <url>
+        <loc>http://localhost:4000/assets/stylesheets/main.css</loc>
+        <lastmod>2020-05-01T07:21:22+00:00</lastmod>
+    </url>
+    
+</urlset>


### PR DESCRIPTION
So far: 
1. All builds fail because the sitemap generator plugin doesn't have access to /build/sitemap.xml
2. _site/sitemap.xml,  file and folder are non existent in the repo, this is required as stated in readme https://github.com/kinnetica/jekyll-plugins
2. Also folder _site and build are gitignored

This may fix it, but it won't ignore _site folder, I don't know which consequenses would that have.

Research:
Original plugin is in https://github.com/kinnetica/jekyll-plugins
which is not maintained since 4 years ago
There is this similiar issue
https://github.com/kinnetica/jekyll-plugins/issues/6
but that fix is applied to a 7-years ago code


Also there exists a more up to date and maintained plugin that we can migrate to.
https://github.com/jekyll/jekyll-sitemap

 
