### PR TITLE
Correct M43 arguments

### DIFF
--- a/_gcode/M043-T.md
+++ b/_gcode/M043-T.md
@@ -16,7 +16,7 @@ notes:
 
 parameters:
   -
-    tag: S
+    tag: P
     optional: true
     description: Start Pin number. If not given, will default to 0
     values:
@@ -53,7 +53,14 @@ parameters:
     values:
       -
         tag: time
-        type: int       
+        type: int
+  -
+    tag: S
+    optional: true
+    description: Perform a Z-servo probe test on the servo with the specified index.
+      -
+        tag: index
+        type: int
 
 examples:
   -


### PR DESCRIPTION
The documentation incorrectly describes the `S` flag as meaning the *start* pin, which is actually assigned to `P`. `S` invokes a Z-servo probe test.