### PR TITLE
Remove STRING_CONFIG_H_AUTHOR M115 reference

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -97,7 +97,7 @@ Marlin now checks for a configuration version and won't compile without this set
 #define CUSTOM_STATUS_SCREEN_IMAGE
 
 ```
-- `STRING_CONFIG_H_AUTHOR` is shown in the Marlin startup message, and is meant to identify the author (and optional variant) of the firmware. Use this setting as a way to uniquely identify all your custom configurations. The startup message is printed when connecting to host software and whenever the board reboots.
+- `STRING_CONFIG_H_AUTHOR` is shown in the Marlin startup message, and is meant to identify the author (and optional variant) of the firmware. Use this setting as a way to uniquely identify all your custom configurations. The startup message is printed whenever the board reboots.
 - `SHOW_BOOTSCREEN` enables the boot screen for LCD controllers.
 - `SHOW_CUSTOM_BOOTSCREEN` shows the bitmap in Marlin/_Bootscreen.h on startup.
 - `CUSTOM_STATUS_SCREEN_IMAGE` shows the bitmap in Marlin/_Statusscreen.h on the status screen.

--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -97,7 +97,7 @@ Marlin now checks for a configuration version and won't compile without this set
 #define CUSTOM_STATUS_SCREEN_IMAGE
 
 ```
-- `STRING_CONFIG_H_AUTHOR` is shown in the Marlin startup message, and is meant to identify the author (and optional variant) of the firmware. Use this setting as a way to uniquely identify all your custom configurations. The startup message is printed when connecting to host software, when the board reboots and M115.
+- `STRING_CONFIG_H_AUTHOR` is shown in the Marlin startup message, and is meant to identify the author (and optional variant) of the firmware. Use this setting as a way to uniquely identify all your custom configurations. The startup message is printed when connecting to host software and whenever the board reboots.
 - `SHOW_BOOTSCREEN` enables the boot screen for LCD controllers.
 - `SHOW_CUSTOM_BOOTSCREEN` shows the bitmap in Marlin/_Bootscreen.h on startup.
 - `CUSTOM_STATUS_SCREEN_IMAGE` shows the bitmap in Marlin/_Statusscreen.h on the status screen.


### PR DESCRIPTION
`STRING_CONFIG_H_AUTHOR` does not show in `M115`.

Reverts a partial change from https://github.com/MarlinFirmware/MarlinDocumentation/commit/7f9add793308b206bb2a8b089c14be7dc725d282 and fixes https://github.com/MarlinFirmware/Marlin/issues/19310.