### PR TITLE
Updating "Configuring Marlin" tutorial

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -14,7 +14,7 @@ Marlin is a huge C++ program composed of many files, but here we'll only be talk
 - `Configuration.h` contains the core settings for the hardware, language and controller selection, and settings for the most common features and components.
 - `Configuration_adv.h` serves up more detailed customization options, add-ons, experimental features, and other esoterica.
 
-These two files contain all of Marlin's build-time configuration options. Simply edit or replace these files before building and uploading Marlin to the board. A variety of pre-built configurations are included in the `config/examples` folder to get you started.
+These two files contain all of Marlin's build-time configuration options. Simply edit or replace these files before building and uploading Marlin to the board. A variety of pre-built configurations are included in the [Configurations repository](https://github.com/MarlinFirmware/Configurations) to get you started.
 
 To use configurations from an earlier version of Marlin, try dropping them into the newer Marlin and building. As part of the build process, the `SanityCheck.h` will print helpful error messages explaining what needs to be changed.
 


### PR DESCRIPTION
The example files have been moved from config/examples to the specific repository.