### PR TITLE
Add requirement to M27 S parameter

### DIFF
--- a/_gcode/M027.md
+++ b/_gcode/M027.md
@@ -17,7 +17,7 @@ parameters:
   -
     tag: S
     optional: true
-    description: Interval between auto-reports. `S0` to disable.
+    description: Interval between auto-reports. `S0` to disable  (requires `AUTO_REPORT_SD_STATUS`)
     values:
       -
         tag: seconds
@@ -25,7 +25,7 @@ parameters:
   -
     tag: C
     optional: true
-    description: Report the filename and long filename of the current file.
+    description: Report the filename and long filename of the current file
 
 
 examples:


### PR DESCRIPTION
The M27 `S` parameter did not specify that it requires `AUTO_REPORT_SD_STATUS`.

I thought it was broken at first, until I dug into the code.