### PR TITLE
Tweak explanation of parameter E

### DIFF
--- a/_gcode/G000-G001.md
+++ b/_gcode/G000-G001.md
@@ -48,7 +48,7 @@ parameters:
   -
     tag: E
     optional: true
-    description: The length of filament to feed into the extruder between the start and end point
+    description: A coordinate on the extrusion "axis" - the position in filament to extrude up to between the start and end point.
     values:
       -
         tag: pos

--- a/_gcode/G000-G001.md
+++ b/_gcode/G000-G001.md
@@ -10,11 +10,12 @@ group: motion
 
 codes: [ G0, G1 ]
 
-related: [ G2, G3, G5 ]
+related: [ G2, G3, G5, M82, M83, G91 ]
 
 notes: |
     - Coordinates are given in millimeters by default. Units may be set to inches by [`G20`](/docs/gcode/G020.html).
     - In Relative Mode ([`G91`](/docs/gcode/G091.html)) all coordinates are interpreted as relative, adding onto the previous position.
+    - In Extruder Relative Mode ([`M83`](/docs/gcode/M083.html)) the E coordinate is interpreted as relative, adding onto the previous E position.
     - A single linear move may generate several smaller moves to the planner due to kinematics and bed leveling compensation. Printing performance can be tuned by adjusting segments-per-second.
 
 devnotes: |

--- a/_gcode/G000-G001.md
+++ b/_gcode/G000-G001.md
@@ -24,7 +24,7 @@ parameters:
   -
     tag: X
     optional: true
-    description: A coordinate on the X axis
+    description: An absolute or relative coordinate on the X axis (in current units).
     values:
       -
         tag: pos
@@ -32,7 +32,7 @@ parameters:
   -
     tag: Y
     optional: true
-    description: A coordinate on the Y axis
+    description: An absolute or relative coordinate on the Y axis (in current units).
     values:
       -
         tag: pos
@@ -40,7 +40,7 @@ parameters:
   -
     tag: Z
     optional: true
-    description: A coordinate on the Z axis
+    description: An absolute or relative coordinate on the Z axis (in current units).
     values:
       -
         tag: pos
@@ -48,7 +48,7 @@ parameters:
   -
     tag: E
     optional: true
-    description: A coordinate on the extrusion "axis" - the position in filament to extrude up to between the start and end point.
+    description: An absolute or relative coordinate on the E (extruder) axis (in current units). The E axis describes the position of the filament in terms of input to the extruder feeder.
     values:
       -
         tag: pos


### PR DESCRIPTION
The previous explanation of "E" made it sound like it was a relative parameter - that doing two consecutive moves with E5 would yield 10 units of extruded filament.  Remembering a different explanation, and checking some generated gcode, this appears to be incorrect, and the E parameter is effectively treated as an axis like the others.