### PR TITLE
Update M043-T.md

### DIFF
--- a/_gcode/M043-T.md
+++ b/_gcode/M043-T.md
@@ -16,7 +16,7 @@ notes:
 
 parameters:
   -
-    tag: P
+    tag: S
     optional: true
     description: Start Pin number. If not given, will default to 0
     values:
@@ -66,7 +66,7 @@ parameters:
 examples:
   -
     pre: Toggle pins 3-6 five times with 1 second low and 1 second high pulses but only if the pin isn't in the protected list.
-    code: M43 T P3 L6 R5 W1000
+    code: M43 T S3 L6 R5 W1000
 
 ---
 


### PR DESCRIPTION
M43.cpp states 'S' as start pin, not 'P'