### PR TITLE
Fix formatting issue

### DIFF
--- a/_gcode/M851.md
+++ b/_gcode/M851.md
@@ -84,7 +84,7 @@ examples:
 
 Set the XYZ distance from the nozzle to the probe trigger-point.
 
-  - The easiest way to get the Z offset value is to:
+The easiest way to get the Z offset value is to:
   - Home the Z axis.
   - Raise Z and deploy the probe.
   - Move Z down slowly until the probe triggers.


### PR DESCRIPTION
The header for this list should not be a list item as it lowers readability. Currently: 

![image](https://user-images.githubusercontent.com/25263210/102109888-3949d800-3e3d-11eb-98ce-d1e1d1a12b6a.png)

Edit: Shouldn't that should possibly be removed entirely? It makes no sense assuming you do not have the Z endstop still plugged in at the same time as the ABL probe..?