### PR TITLE
Update G34 Target Accuracy description

### DIFF
--- a/_gcode/G034.md
+++ b/_gcode/G034.md
@@ -21,7 +21,7 @@ parameters:
   -
     tag: T
     optional: true
-    description: Target accuracy - must be between 0.001 - 1.0
+    description: Target accuracy - must be between 0.01 - 1.0
   -
     tag: A
     optional: true


### PR DESCRIPTION
### Description

Update `G34` Target Accuracy description to correctly reference a value between 0.01 - 1.0.

From [G34_M422.cpp](https://github.com/MarlinFirmware/Marlin/blob/e9677594ea164319dea1c6cc2dc905237ad0dec4/Marlin/src/gcode/calibrate/G34_M422.cpp#L115-L119):
```cpp
      const float z_auto_align_accuracy = parser.floatval('T', Z_STEPPER_ALIGN_ACC);
      if (!WITHIN(z_auto_align_accuracy, 0.01f, 1.0f)) {
        SERIAL_ECHOLNPGM("?(T)arget accuracy out of bounds (0.01-1.0).");
        break;
      }
```

### Benefits

Correct documentation.

### Related Issues

https://github.com/MarlinFirmware/MarlinDocumentation/issues/354