### PR TITLE
Update M305 Steinhart-Hart Coefficient tag

### DIFF
--- a/_gcode/M305.md
+++ b/_gcode/M305.md
@@ -46,7 +46,7 @@ parameters:
         tag: beta
         type: int
   -
-    tag: T
+    tag: C
     optional: true
     description: Steinhart-Hart Coefficient 'C'
     values:


### PR DESCRIPTION
### Description

Update Update `M305` Steinhart-Hart Coefficient tag to correctly reference `C` instead of `T`

From [M305.cpp](https://github.com/MarlinFirmware/Marlin/blob/45b11553f40c48f03bfa10b542f27a9555cb2583/Marlin/src/gcode/config/M305.cpp#L69-L71):
```cpp
    if (parser.seen('C')) // Steinhart-Hart C coefficient
      if (!thermalManager.set_sh_coeff(t_index, parser.value_float()))
        SERIAL_ECHO_MSG("!Invalid Steinhart-Hart C coeff. (-0.01 < C < +0.01)");
```

### Benefits

Correct documentation.

### Related Issues

https://github.com/MarlinFirmware/MarlinDocumentation/issues/350