### PR TITLE
Add M303 Auto-Tune PID examples

### DIFF
--- a/_gcode/M303.md
+++ b/_gcode/M303.md
@@ -56,8 +56,16 @@ parameters:
         tag: flag
         type: bool
 
-example:
+examples:
+-
+  pre: 'Auto-tune hotend at 210 °C for 8 cycles:'
+  code:
+    - M303 E0 C8 S210
 
+-
+  pre: 'Auto-tune bed at 60 °C for 8 cycles:'
+  code:
+    - M303 E-1 C8 S60
 ---
 
 This command initiates a process of heating and cooling to determine the proper PID values for the specified hotend or the heated bed.


### PR DESCRIPTION
### Description

Add `M303` Auto-Tune PID examples

### Benefits

Improve documentation.

### Related Issues

None.