### PR TITLE
[Enhancement] lin_advance tool: Heat bed before homing

### DIFF
--- a/_tools/lin_advance/k-factor.js
+++ b/_tools/lin_advance/k-factor.js
@@ -190,12 +190,12 @@ function genGcode() {
                   ';\n' +
                   'G21 ; Millimeter units\n' +
                   'G90 ; Absolute XYZ\n' +
-                  'M83 ; Relative E\n' +
-                  'G28 ; Home all axes\n' +
+                  'M83 ; Relative E\n' +  
                   'T' + TOOL_INDEX + ' ; Switch to tool ' + TOOL_INDEX + '\n' +
                   'G1 Z5 F100 ; Z raise\n' +
                   'M104 S' + NOZZLE_TEMP + ' ; Set nozzle temperature (no wait)\n' +
                   'M190 S' + BED_TEMP + ' ; Set bed temperature (wait)\n' +
+                  'G28 ; Home all axes\n' +
                   'M109 S' + NOZZLE_TEMP + ' ; Wait for nozzle temp\n' +
                   (BED_LEVELING !== '0' ? BED_LEVELING + '; Activate bed leveling compensation\n' : '') +
                   'M204 P' + ACCELERATION + ' ; Acceleration\n' +


### PR DESCRIPTION
**Description**
Most people with auto bed leveling require their bed to heat up **before** homing their z axis, as most heated beds warp significantly and can mean the difference between a failed and a successful first layer. My first layer using this gcode was failing without homing after heating the bed.

**Benefits**
Fewer failed first layers and having to manually change the gcode for users running ABL.

**Related Issues**
None.