### PR TITLE
Update M412 to document R, D, H options.

### DIFF
--- a/_gcode/M412.md
+++ b/_gcode/M412.md
@@ -19,7 +19,7 @@ parameters:
   -
     tag: D
     optional: true
-    description: Set the filament runout distance, in mm.
+    description: Set the filament runout distance.
     values:
       -
         type: float

--- a/_gcode/M412.md
+++ b/_gcode/M412.md
@@ -1,7 +1,7 @@
 ---
 tag: m0412
 title: Filament Runout
-brief: Enable / disable filament runout detection
+brief: Get/set filament runout detection parameters
 author: thinkyhead
 
 requires: FILAMENT_RUNOUT_SENSOR
@@ -12,8 +12,25 @@ codes: [ M412 ]
 
 notes:
   - Requires `FILAMENT_RUNOUT_SENSOR`.
+  - Parameter `D` requires `FILAMENT_RUNOUT_DISTANCE_MM`.
+  - Parameter `H` requires `HOST_ACTION_COMMANDS`.
 
 parameters:
+  -
+    tag: D
+    optional: true
+    description: Set the filament runout distance, in mm.
+    values:
+      -
+        type: float
+        tag: linear
+  -
+    tag: H
+    optional: true
+    description: Flag to enable or disable host handling of a filament runout.
+    values:
+      -
+        type: bool
   -
     tag: S
     optional: true
@@ -21,10 +38,18 @@ parameters:
     values:
       -
         type: bool
+        
+  -
+    tag: R
+    optional: true
+    description: Flag to reset the filament runout sensor. Not needed with `S`.
+    values:
+      -
+        type: bool
 
 examples:
   -
-    pre: Enable filament runout detection
+    pre: Enable (and reset) filament runout detection
     code: M412 S1
   -
     pre: Disable filament runout detection
@@ -34,7 +59,14 @@ examples:
     code: |
       M412
       Filament runout ON
-
+  -
+    pre: Set filament runout distance
+    code: |
+      M412 D35 ; requires FILAMENT_RUNOUT_DISTANCE_MM
+      M412
+      Filament runout ON
+      Filament runout distance (mm): 35
+      
 ---
 
-Enable or disable filament runout detection. When filament sensors are enabled, Marlin will respond to a filament runout by running the configured G-code (usually [`M600` Filament Change](/docs/gcode/M600.html)). When filament runout detection is disabled, Marlin will take no action for filament runout.
+Get or set filament runout status and distance. Omit all parameters to get a report of the current stats. Enable or disable filament runout detection with `S` and set distance with `D`. When filament sensors are enabled, Marlin will respond to a filament runout by running the configured G-code (usually [`M600` Filament Change](/docs/gcode/M600.html)). When filament runout detection is disabled, Marlin will take no action for filament runout.


### PR DESCRIPTION
Adds missing information for *R*eset, *D*istance, and *H*ost handling of a runout.