### PR TITLE
Note that G29W requires UBL_DEVEL_DEBUGGING

### DIFF
--- a/_gcode/G029-ubl.md
+++ b/_gcode/G029-ubl.md
@@ -280,7 +280,7 @@ parameters:
     tag: W
     optional: true
     description: |
-      **_What?_**: Display valuable UBL data.
+      **_What?_**: Display valuable UBL data. (Requires `UBL_DEVEL_DEBUGGING`)
     values:
       -
         type: bool


### PR DESCRIPTION
I was pretty confused why `G29 W` was not outputting anything until I looked at the code; it requires `UBL_DEVEL_DEBUGGING` to be defined at compile time. Add a note to the docs pointing this out.