### PR TITLE
Update M043-T.md

### DIFF
--- a/_gcode/M043-T.md
+++ b/_gcode/M043-T.md
@@ -3,7 +3,7 @@ tag: m0043b
 title: Toggle Pins
 brief: Get information about pins.
 author: thinkyhead
-
+contrib: [ TwoRedCells ]
 experimental: true
 requires: PINS_DEBUGGING
 group: debug
@@ -53,14 +53,6 @@ parameters:
     values:
       -
         tag: time
-        type: int
-  -
-    tag: S
-    optional: true
-    description: Perform a Z-servo probe test on the servo with the specified index.
-    values:
-      -
-        tag: index
         type: int
 
 examples:


### PR DESCRIPTION
Removed erroneous reference to the S parameter intended for the M43 (not M43 T) variant of the command.