### PR TITLE
Update G060.md

### DIFF
--- a/_gcode/G060.md
+++ b/_gcode/G060.md
@@ -3,7 +3,7 @@ tag: g060
 title: Save Current Position
 brief: Save current position to specified slot
 author: shitcreek
-contrib: Hans007a
+contrib: [ Hans007a, TwoRedCells ]
 codes: [ G60 ]
 related: [ G61 ]
 
@@ -21,4 +21,4 @@ example:
       - G60 S1 ; Save current position to slot 1
 ---
 
-Save current position to the specified slot. Default slot is 0. Total available slots, `SAVED_POSITIONS`, is set `Configuration_adv.h`. Default slot is 0. Use [`G0`](/docs/gcode/G000-G001.html) or [`G1`](/docs/gcode/G000-G001.html) with the R0, R1 or R2 parameter to move the current tool to a saved position.
+Save current position to the specified slot (defaulting to 0 if unspecified). Total available slots, `SAVED_POSITIONS`, is set `Configuration_adv.h`. Use [`G061`](/docs/gcode/G0061.html) to move the current tool to a saved position.

--- a/_gcode/G060.md
+++ b/_gcode/G060.md
@@ -21,4 +21,4 @@ example:
       - G60 S1 ; Save current position to slot 1
 ---
 
-Save current position to the specified slot (defaulting to 0 if unspecified). Total available slots, `SAVED_POSITIONS`, is set `Configuration_adv.h`. Use [`G061`](/docs/gcode/G0061.html) to move the current tool to a saved position.
+Save current position to the specified slot (defaults to 0 if unspecified). Total available slots, `SAVED_POSITIONS`, is set in `Configuration_adv.h`. Use [`G061`](/docs/gcode/G0061.html) to move the current tool to a saved position.


### PR DESCRIPTION
Removed reference to erroneous reference (legacy code?) to an non-existent R parameter to the G0/G1 commands.