### PR TITLE
Linear Advance Tool: Home Before Z Raise

### DIFF
--- a/_tools/lin_advance/k-factor.js
+++ b/_tools/lin_advance/k-factor.js
@@ -190,12 +190,12 @@ function genGcode() {
                   ';\n' +
                   'G21 ; Millimeter units\n' +
                   'G90 ; Absolute XYZ\n' +
-                  'M83 ; Relative E\n' +  
+                  'M83 ; Relative E\n' +
                   'T' + TOOL_INDEX + ' ; Switch to tool ' + TOOL_INDEX + '\n' +
-                  'G1 Z5 F100 ; Z raise\n' +
                   'M104 S' + NOZZLE_TEMP + ' ; Set nozzle temperature (no wait)\n' +
                   'M190 S' + BED_TEMP + ' ; Set bed temperature (wait)\n' +
                   'G28 ; Home all axes\n' +
+                  'G1 Z5 F100 ; Z raise\n' +
                   'M109 S' + NOZZLE_TEMP + ' ; Wait for nozzle temp\n' +
                   (BED_LEVELING !== '0' ? BED_LEVELING + '; Activate bed leveling compensation\n' : '') +
                   'M204 P' + ACCELERATION + ' ; Acceleration\n' +


### PR DESCRIPTION
### Description

Changes in #360 moved `G28` after the `G1 Z5 F100` line which can cause the nozzle to drag across your bed (as reported in #386), so this PR shifts the Z move after homing.

### Benefits

Nozzle won't scrape across your bed.

### Related Issues

Fixes https://github.com/MarlinFirmware/MarlinDocumentation/issues/386