### PR TITLE
Add ABC diagonal rod trim parameters

### DIFF
--- a/_gcode/M665.md
+++ b/_gcode/M665.md
@@ -2,7 +2,7 @@
 tag: m0665
 title: Delta Configuration
 brief: Set delta geometry values
-author: thinkyhead
+author: thinkyhead, thisiskeithb
 
 requires: DELTA
 group: none
@@ -69,6 +69,27 @@ parameters:
     tag: Z
     optional: true
     description: Gamma (Tower 3) angle trim
+    values:
+      -
+        type: float
+  -
+    tag: A
+    optional: true
+    description: Alpha (Tower 1) diagonal rod trim
+    values:
+      -
+        type: float
+  -
+    tag: B
+    optional: true
+    description: Beta  (Tower 2) diagonal rod trim
+    values:
+      -
+        type: float
+  -
+    tag: C
+    optional: true
+    description: Gamma (Tower 3) diagonal rod trim
     values:
       -
         type: float


### PR DESCRIPTION
### Description

Add ABC diagonal rod trim parameters to match [`M665`](https://github.com/MarlinFirmware/Marlin/blob/7d7200474202925d61c3c06703fd7291fa20a53d/Marlin/src/gcode/calibrate/M665.cpp#L33-L45):

```cpp
  /**
   * M665: Set delta configurations
   *
   *    H = delta height
   *    L = diagonal rod
   *    R = delta radius
   *    S = segments per second
   *    X = Alpha (Tower 1) angle trim
   *    Y = Beta  (Tower 2) angle trim
   *    Z = Gamma (Tower 3) angle trim
   *    A = Alpha (Tower 1) diagonal rod trim
   *    B = Beta  (Tower 2) diagonal rod trim
   *    C = Gamma (Tower 3) diagonal rod trim
   */
```

### Benefits

Improve documentation.

### Related Issues

N/A. Found on [Marlin's Facebook group](https://www.facebook.com/groups/marlinfirmware/permalink/3222293031207007/).