### PR TITLE
add documentation for M105R

### DIFF
--- a/_gcode/M105.md
+++ b/_gcode/M105.md
@@ -15,6 +15,13 @@ notes:
 
 parameters:
   -
+    tag: R
+    optional: true
+    description: Report redundant temperature sensor as well
+    values:
+      -
+        type: flag
+  -
     tag: T
     optional: true
     description: Hotend index


### PR DESCRIPTION
Adds information about the `R`edundant temperature sensor option.