### PR TITLE
Update note in M876

### DIFF
--- a/_gcode/M876.md
+++ b/_gcode/M876.md
@@ -10,7 +10,7 @@ group: hosts
 codes: [ M876 ]
 
 notes:
-  - Must disable `EMERGENCY_PARSER`
+  - `EMERGENCY_PARSER` Changes how M876 is handeled. With EMERGENCY_PARSER enabled the standard gcode is disabled but the emgency parser takes care of it.    
 
 parameters:
   -


### PR DESCRIPTION
Disabling EMERGENCY_PARSER is not a requirement for M876 to work. It just switches from being processed as a normal gcode to being part of the emergency passer.
(unless there is something else i'm missing)