### PR TITLE
Add missing dashes to YAML frontmatter for M3/M4/M303 markdown

### DIFF
--- a/_gcode/M003.md
+++ b/_gcode/M003.md
@@ -25,7 +25,7 @@ parameters:
       -
         tag: power
         type: byte
-
+  -
     tag: 0
     optional: true
     description: Spindle speed or laser power in PWM 0-255 value range
@@ -33,7 +33,7 @@ parameters:
       -
         tag: power
         type: byte
-
+  -
     tag: I
     optional: true
     description: Inline mode ON / OFF.

--- a/_gcode/M004.md
+++ b/_gcode/M004.md
@@ -25,7 +25,7 @@ parameters:
       -
         tag: power
         type: byte
-
+  -
     tag: 0
     optional: true
     description: Spindle speed or laser power in PWM 0-255 value range
@@ -33,7 +33,7 @@ parameters:
       -
         tag: power
         type: byte
-
+  -
     tag: I
     optional: true
     description: Inline mode ON / OFF.

--- a/_gcode/M303.md
+++ b/_gcode/M303.md
@@ -55,7 +55,7 @@ parameters:
       -
         tag: flag
         type: bool
-
+  -
     tag: D
     optional: false
     description: Toggle PID debug output on / off (and take no further action). (Requires `PID_DEBUG`)


### PR DESCRIPTION
This PR adds (presumbly) missing dashes that separate entries in the `parameters` key of the YAML frontmatter for the following files:

 * M003.md
 * M004.md
 * M303.md

Without these dashes, the parameters key will either throw a validation error or be silently compacted down to whichever parameter is defined last.

You can see the outcome of this on the live site:

![missing params](https://i.imgur.com/WlWL3cc.png)

Two of the three parameters defined in M003.md are missing.