### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem 'kramdown', '>= 2.3.0'
 gem 'naturally', '>= 2.2.1'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 gem 'tzinfo-data', '>= 1.2020.1'
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
This happens because webrick is no longer a bundled gem in Ruby 3.0. From https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/:

The following libraries are no longer bundled gems or standard libraries. Install the corresponding gems to use these features.

sdbm
webrick
net-telnet
xmlrpc