### PR TITLE
Update G029-ubl.md to change an example

### DIFF
--- a/_gcode/G029-ubl.md
+++ b/_gcode/G029-ubl.md
@@ -334,7 +334,7 @@ examples:
      M502          ; Load configuration defaults.
      M500          ; Save configuration to EEPROM. M502 followed by M500 is suggested post flash to wipe the eeprom of invalid old settings.
 
-     M190 S65      ; Heat Bed to 65C. Not required, but having the printer at temperature may help accuracy.
+     M140 S65      ; Heat Bed to 65C. Not required, but having the printer at temperature may help accuracy.
      M104 S210     ; Heat Hotend to 210C. Not required, but having the printer at temperature may help accuracy.
 
      G29 T         ; View the Z compensation values.


### PR DESCRIPTION
Changed the command to heat the bed in the optional settings from M190 to M140. The M190 waits for bed to finish heating until processing more commands where the M140 starts the heating process and continues on. This change makes the documentation consistent with the use of M104 to heat the hotend instead of M109 which waits until the hotend reaches the temperature specified.