### PR TITLE
Link to Cura M486 post processing script

### DIFF
--- a/_gcode/M486.md
+++ b/_gcode/M486.md
@@ -13,6 +13,7 @@ notes: |
   This G-code may not be widely supported by slicers for a while, but they do include helpful comments in the G-code output that includes the current object. So for now you can use a post-processing script to convert these comments into [`M486`](/docs/gcode/M486.html) commands.
   #### Slicer post-processing scripts:
     - [M486 for Průša Slicer](//github.com/paukstelis/PrusaSlicer-M486) by [Paul Paukstelis](//github.com/paukstelis).
+    - [M486 for Cura](//github.com/shinmai/cura-M486) by [Aapo Saaristo](//twitter.com/shinmai).
 
 parameters:
   -


### PR DESCRIPTION
Wanting to use M486 with Cura and getting tired of editing G-code outside of the slicer, I made a simple script for Cura's post processing extension to inject the proper G-code for object indexing.  
Thought it might be useful for other Cura users and figured the Marlin documentation is where people would be most likely to look.