### PR TITLE
Fix frontmatter definition for examples for G32

### DIFF
--- a/_gcode/G032.md
+++ b/_gcode/G032.md
@@ -13,7 +13,7 @@ codes: [ G32 ]
 
 notes:
 
-example:
+examples:
   -
     pre: Undock the sled
     code: G32


### PR DESCRIPTION
In all files _other_ than G032.md, the key used in frontmatter for examples is `examples`. This PR fixes G032 so that it dovetails with the existing style.