### PR TITLE
Marlin 2.0.x changed to MULTI_NOZZLE_DUPLICATION from DUAL_NOZZLE_DUPLICATION_MODE

### DIFF
--- a/_gcode/M605.md
+++ b/_gcode/M605.md
@@ -1,10 +1,10 @@
 ---
 tag: m0605
-title: Dual Nozzle Mode
-brief: Set the behavior mode for dual nozzles
+title: Multi Nozzle Mode
+brief: Set the behavior mode for Multiple fixed nozzles like Dual extruders or for DUAL_X_CARRIAGE printers
 author: thinkyhead
 
-requires: DUAL_NOZZLE_DUPLICATION_MODE|DUAL_X_CARRIAGE
+requires: MULTI_NOZZLE_DUPLICATION|DUAL_X_CARRIAGE
 group: control
 
 codes: [ M605 ]
@@ -47,8 +47,8 @@ examples:
 
 ---
 
-This command behaves differently for `DUAL_X_CARRIAGE` vs. `DUAL_NOZZLE_DUPLICATION_MODE`
+This command behaves differently for `DUAL_X_CARRIAGE` vs. `MULTI_NOZZLE_DUPLICATION`
 
-For `DUAL_NOZZLE_DUPLICATION_MODE` the `S2` parameter enables duplication mode. Any other value disables it.
+For `MULTI_NOZZLE_DUPLICATION` the `S2` parameter enables duplication mode. Any other value disables it.
 
 For `DUAL_X_CARRIAGE`, this command sets the Dual X mode. See the description of `S` below.

--- a/_gcode/M605.md
+++ b/_gcode/M605.md
@@ -1,7 +1,7 @@
 ---
 tag: m0605
 title: Multi Nozzle Mode
-brief: Set the behavior mode for Multiple fixed nozzles like Dual extruders or for DUAL_X_CARRIAGE printers
+brief: Set the behavior mode for a multiple nozzle setup
 author: thinkyhead
 
 requires: MULTI_NOZZLE_DUPLICATION|DUAL_X_CARRIAGE
@@ -46,9 +46,8 @@ parameters:
 examples:
 
 ---
+Set the behavior mode for multiple fixed nozzles such as a Dual Extruder or `DUAL_X_CARRIAGE` machine.
 
-This command behaves differently for `DUAL_X_CARRIAGE` vs. `MULTI_NOZZLE_DUPLICATION`
-
-For `MULTI_NOZZLE_DUPLICATION` the `S2` parameter enables duplication mode. Any other value disables it.
-
-For `DUAL_X_CARRIAGE`, this command sets the Dual X mode. See the description of `S` below.
+This command behaves differently for `DUAL_X_CARRIAGE` vs. `MULTI_NOZZLE_DUPLICATION`:
+- For `MULTI_NOZZLE_DUPLICATION` the `S2` parameter enables duplication mode. Any other value disables it.
+- For `DUAL_X_CARRIAGE`, this command sets the Dual X mode. See the description of `S` below.


### PR DESCRIPTION
For M605 
MULTI_NOZZLE_DUPLICATION changed from DUAL_NOZZLE_DUPLICATION_MODE

Marlin 2.0.x uses MULTI_NOZZLE_DUPLICATION
Marlin 1.1.9.x uses DUAL_NOZZLE_DUPLICATION_MODE
Current Documentation is out of date with the current implementation of M605 for Marlin 2.0.x.
This change corrects the documentation to reflect the current Marlin 2.0.x implementation