### PR TITLE
Updated docs for new C parameter to G30 and M48

### DIFF
--- a/_gcode/G030.md
+++ b/_gcode/G030.md
@@ -12,6 +12,14 @@ codes: [ G30 ]
 
 parameters:
   -
+    tag: C
+    optional: true
+    description: Probe with temperature compensation enabled (`PTC_PROBE`, `PTC_BED`, `PTC_HOTEND`)
+    values:
+      -
+        type: bool
+        default: 1
+  -
     tag: X
     optional: true
     description: X probe position

--- a/_gcode/M048.md
+++ b/_gcode/M048.md
@@ -14,6 +14,14 @@ notes:
 
 parameters:
   -
+    tag: C
+    optional: true
+    description: Probe with temperature compensation enabled (`PTC_PROBE`, `PTC_BED`, `PTC_HOTEND`)
+    values:
+      -
+        type: bool
+        default: 1
+  -
     tag: E
     optional: true
     description: Engage for each probe


### PR DESCRIPTION
Bringing documentation in line with probe temperature compensation changes. See issue [23047](https://github.com/MarlinFirmware/Marlin/issues/23047) and PR [23764](https://github.com/MarlinFirmware/Marlin/pull/23764).