### PR TITLE
Update M048.md

### DIFF
--- a/_gcode/M048.md
+++ b/_gcode/M048.md
@@ -1,6 +1,6 @@
 ---
 tag: m0048
-title: Probe Accuracy Test
+title: Probe Repeatability Test
 brief: Measure Z Probe repeatability.
 author: thinkyhead
 
@@ -77,4 +77,4 @@ examples:
 
 ---
 
-Probes come in many flavors and as such have varying levels of accuracy, reliability, and repeatability, depending on several factors. This command tests the probe for accuracy and produces a standard deviation based on two or more probes of the same XY position.
+Probes come in many flavors and as such have varying levels of accuracy, reliability, and repeatability, depending on several factors. This command tests the probe for repeatability (precision) and produces a standard deviation based on two or more probes of the same XY position.


### PR DESCRIPTION
Per issue #439 which states:

Can we change the documentation for M48 so that it is called the " Probe Repeatability Test" (matches the define "Z_MIN_PROBE_REPEATABILITY_TEST"). Also, we should change the body of the documentation so that instead of saying "This command tests the probe for accuracy..." instead it should say "This command tests the probe for repeatability (precision)..." I particularly think the documentation should state both "repeatability" as the common term and also "precision" which is the more "engineering" term.

It seems many folks think this command can demonstrate that their probe measurements are accurate (give a correct measurement value) when actually all the test can prove is that the probe gives the same (but perhaps wrong) measurement value upon back-to-back repeated measurements, I have reason to believe (can share data if anyone is interested) that some probes are in fact quite precise but woefully inaccurate. It is that inaccuracy that can lead to a poor mesh point value measurements and therefore poor auto bilinear mesh leveling. Poor auto bilinear mesh leveling can be easily observed using a commonly practiced bed leveling test that is the printing of an array of single-layer squares (same pattern as the mesh points) and checking to see that all the squares have acceptable "squish". Happy to discuss this and the general topic of manual and auto bilinear mesh bed leveling to any like-minded folks.