### PR TITLE
Set base pre bg color

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -335,6 +335,7 @@ h1+h2 { color: #BBC; }
 a, a:hover { color: var(--color-link); }
 
 code { color: var(--color-code); background-color: var(--color-code-bg); }
+pre { background-color: var(--color-pre-bg); }
 pre, pre>code { color: var(--color-pre); }
 pre.highlight{ background-color: var(--color-highlight-bg); }
 


### PR DESCRIPTION
pre tags previously displayed the same light grey bg color even on 
dark mode, rather than using the --color-pre-bg variable, which lead to 
very low contrast text when using dark mode, e.g. 
https://marlinfw.org/docs/features/unified_bed_leveling.html#synopsis

Every other instance I could find of pre tags used the highlight class, and didn't have this issue, nor would those instances be affected by this change.