### PR TITLE
Update G000-G001.md

### DIFF
--- a/_gcode/G000-G001.md
+++ b/_gcode/G000-G001.md
@@ -84,6 +84,15 @@ examples:
       - G1 X50 Y25.3 E22.4 F3000
     post: However, in the above example, we set a feedrate of 1500 mm/min on line 1 then do the move described above, accelerating to a feedrate of 3000 mm/min (if possible). The extrusion will accelerate along with the X and Y movement, so everything stays synchronized.
 
+    code:
+      - G91 
+      - G1 S1 X-700.0 F9600.
+      - G1 X4.0 F600.00
+      - G1 S1 X-10.0
+      - G92 X0
+      - G90
+    post: In the above example, we home a single axis (with stop; S1). First we set the machine to relative position (G91). Set a feedrate of 9600 mm/min on line 2 then do the move described above, stopping the axis when homing stop is activated (line 2 axis move should be longer than machine axis). Reducing speed to 600 mm/min for accuracy and moving off the axis homing stop. Return to homing stop with reduced speed on line 4. Reset axis 0 position and return to absolute positioning. 
+
 ---
 The `G0` and `G1` commands add a linear move to the queue to be performed after all previous moves are completed. These commands yield control back to the command parser as soon as the move is queued, but they may delay the command parser while awaiting a slot in the queue.
 


### PR DESCRIPTION
Adding example of single axis homing with S1 option. I had issues with re homing machine between layers with G28. Was able to find older examples using S1 option within G1 (duet3d.dozuki.com/Wiki/ConfiguringRepRapFirmwareCartesianPrinter#Section_Homing_X_and_Y). But did not find any examples of using S1 in your documentation or examples of the canned cycles G28 references or their location within firmware.