### PR TITLE
Replaced old logo with newer one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 This repository contains the raw documentation for [Marlin 3D printer firmware](//github.com/MarlinFirmware/Marlin) which is regularly deployed to [marlinfw.org](//marlinfw.org/). This documentation is open and available on Github so anyone may contribute by completing, correcting, or creating articles.
 
-![Marlin logo](assets/images/logo/marlin/small.png)
+<div align = center>
+
+<img
+    width = 300
+    src = https://raw.githubusercontent.com/MarlinFirmware/Marlin/bugfix-2.1.x/buildroot/share/pixmaps/logo/marlin-outrun-nf-500.png
+/>
+
+</div>
 
 ## Technical details
 


### PR DESCRIPTION
Fixes this horrible mess:

![oh god](https://user-images.githubusercontent.com/85485984/208272815-a58746c2-9a6b-4a7b-922f-6de206b9d467.png)

Preview: https://github.com/ElectronicsArchiver/MarlinDocumentation
