### PR TITLE
Fix M306 autotune message

### DIFF
--- a/_gcode/M306.md
+++ b/_gcode/M306.md
@@ -78,7 +78,7 @@ parameters:
   -
     tag: T
     optional: true
-    description: Autotune the active extruder.
+    description: Autotune the selected extruder.
 
 examples:
 -


### PR DESCRIPTION
T argument now autotune E selected extruder (or active if omitted)