### PR TITLE
Rename "Starting Temperature" to "Ambient Starting Temperature"

### DIFF
--- a/_features/model_predictive_control.md
+++ b/_features/model_predictive_control.md
@@ -58,7 +58,7 @@ MPC_AMBIENT_XFER_COEFF_FAN255 0.0998
 
 If `M306 T` doesn't work –e.g., with positive temperature coefficient (PTC) hotends– MPC can be configured manually.
 
-1. Start with the part cooling fan off and hotend cold. Record the ambient starting  temperature Ta. e.g., Ta = 20°C.
+1. Start with the part cooling fan off and hotend cold. Record the ambient starting temperature Ta. e.g., Ta = 20°C.
 1. Set the temperature to 200°C and then back to 0°C once it reaches around 200°C. Measure the curve of temperature
 vs time while the hotend is heating, starting at time = 0s.
 1. Measure the fastest rate Rf at which temperature increases in °C/s. e.g., Rf = 3°C/s.

--- a/_features/model_predictive_control.md
+++ b/_features/model_predictive_control.md
@@ -58,17 +58,17 @@ MPC_AMBIENT_XFER_COEFF_FAN255 0.0998
 
 If `M306 T` doesn't work –e.g., with positive temperature coefficient (PTC) hotends– MPC can be configured manually.
 
-1. Start with the part cooling fan off and hotend cold. Record the starting temperature Ts. e.g., Ts = 20°C.
+1. Start with the part cooling fan off and hotend cold. Record the ambient starting  temperature Ta. e.g., Ta = 20°C.
 1. Set the temperature to 200°C and then back to 0°C once it reaches around 200°C. Measure the curve of temperature
 vs time while the hotend is heating, starting at time = 0s.
 1. Measure the fastest rate Rf at which temperature increases in °C/s. e.g., Rf = 3°C/s.
 1. Divide the heater power by Rf to get `MPC_BLOCK_HEAT_CAPACITY` in J/K. e.g., 40W / 3°C/s = 13.33 J/K.
 1. Measure the temperature Tf and time tf of the point where temperature was increasing fastest.
-1. `MPC_SENSOR_RESPONSIVENESS` is Rf / (Rf x tf + Ts - Tf). e.g., for tf = 10s and Tf = 35°C, this is 3°C/s / ( 3°C/s x 10s + 20°C - 35°C) = 0.2 K/s/K.
+1. `MPC_SENSOR_RESPONSIVENESS` is Rf / (Rf x tf + Ta - Tf). e.g., for tf = 10s and Tf = 35°C, this is 3°C/s / ( 3°C/s x 10s + 20°C - 35°C) = 0.2 K/s/K.
 1. Set these values with `M306` and set the temperature to 200°C.
 1. MPC should eventually settle at a stable temperature around 200°C.
 1. Use `M105` to find the PWM output required to maintain 200°C. e.g., if `M105` returns `T:200.12 /200.00 B:18.38 /0.00 P:18.24 /0.00 @:41 B@:0` it is the value `41` after the first `@` so PWM = 41.
-1. `MPC_AMBIENT_XFER_COEFF` is PWM / 127 * heater power / (200°C - Ts). e.g., 41 / 127 * 40 W / (200°C - 20°C) = 0.072 W/K.
+1. `MPC_AMBIENT_XFER_COEFF` is PWM / 127 * heater power / (200°C - Ta). e.g., 41 / 127 * 40 W / (200°C - 20°C) = 0.072 W/K.
 1. Find `MPC_AMBIENT_XFER_COEFF_FAN255` by repeating the last three steps with the fan on full.
 
 ## Advanced Configuration


### PR DESCRIPTION
Used `Ta` to represent ambient "starting temperature" (rather than `Ts` for "starting temperature") to avoid confusion with the variables in the "Model Details & Tuning Algorithm" sections, where `Ta` is "ambient temperature" and `Ts` is "sensor temperature".