### PR TITLE
Add documentation on geometry report

### DIFF
--- a/_gcode/M115.md
+++ b/_gcode/M115.md
@@ -42,4 +42,8 @@ When `EXTENDED_CAPABILITIES_REPORT` and `M115_GEOMETRY_REPORT` are enabled, Marl
 area:{full:{min:{x:0,y:0,z:0,i:0,j:0,k:0,u:0,v:0,w:0},max:{x:200,y:200,z:200,i:0,j:0,k:0,u:0,v:0,w:0}},work:{min:{x:0,y:0,z:0,i:0,j:0,k:0},max:{x:200,y:200,z:200,i:0,j:0,k:0,u:0,v:0,w:0}}}
 ```
 
-Please note `i,j,k,u,v,w` are used for additional axis. They are initialized to 0 if not used.
+Coordinates are only reported for declared linear axes. It means for a classic cartesian printer, the geometry report will look like:
+
+```
+area:{full:{min:{x:0,y:0,z:0},max:{x:200,y:200,z:200}},work:{min:{x:0,y:0,z:0},max:{x:200,y:200,z:200}}}
+```

--- a/_gcode/M115.md
+++ b/_gcode/M115.md
@@ -35,3 +35,11 @@ Cap:EMERGENCY_PARSER:1
 ```
 
 Hosts use this information to improve interoperability, so it's a good feature to enable.
+
+When `EXTENDED_CAPABILITIES_REPORT` and `M115_GEOMETRY_REPORT` are enabled, Marlin also report the printer geometry:
+
+```
+area:{full:{min:{x:0,y:0,z:0,i:0,j:0,k:0,u:0,v:0,w:0},max:{x:200,y:200,z:200,i:0,j:0,k:0,u:0,v:0,w:0}},work:{min:{x:0,y:0,z:0,i:0,j:0,k:0},max:{x:200,y:200,z:200,i:0,j:0,k:0,u:0,v:0,w:0}}}
+```
+
+Please note `i,j,k,u,v,w` are used for additional axis. They are initialized to 0 if not used.

--- a/_gcode/M115.md
+++ b/_gcode/M115.md
@@ -36,13 +36,13 @@ Cap:EMERGENCY_PARSER:1
 
 Hosts use this information to improve interoperability, so it's a good feature to enable.
 
-When `EXTENDED_CAPABILITIES_REPORT` and `M115_GEOMETRY_REPORT` are enabled, Marlin also report the printer geometry:
+With `EXTENDED_CAPABILITIES_REPORT` and `M115_GEOMETRY_REPORT` enabled, Marlin will also report detailed printer geometry:
 
 ```
 area:{full:{min:{x:0,y:0,z:0,i:0,j:0,k:0,u:0,v:0,w:0},max:{x:200,y:200,z:200,i:0,j:0,k:0,u:0,v:0,w:0}},work:{min:{x:0,y:0,z:0,i:0,j:0,k:0},max:{x:200,y:200,z:200,i:0,j:0,k:0,u:0,v:0,w:0}}}
 ```
 
-Coordinates are only reported for declared linear axes. It means for a classic cartesian printer, the geometry report will look like:
+Coordinates are only reported for declared linear axes. So for a classic cartesian printer, the geometry report will look like:
 
 ```
 area:{full:{min:{x:0,y:0,z:0},max:{x:200,y:200,z:200}},work:{min:{x:0,y:0,z:0},max:{x:200,y:200,z:200}}}


### PR DESCRIPTION
Hi,

As stated in the title, this PR add documentation regarding the optional geometry report the M115 gcode command can provide.

I also created a PR in Octoprint to handle this in the virtual printer (https://github.com/OctoPrint/OctoPrint/pull/4799).