### PR TITLE
🩹 Fix M915 Video Location Reference

### DIFF
--- a/_gcode/M915.md
+++ b/_gcode/M915.md
@@ -45,7 +45,7 @@ example:
 
 ---
 
-The command aims to align the ends of the X gantry (for a Průša i3-style printer). See the [video demonstration](//youtu.be/JqH41K2vq0g?t=300) above.
+The command aims to align the ends of the X gantry (for a Průša i3-style printer). See the [video demonstration](//youtu.be/JqH41K2vq0g?t=300) below.
 
 Using the given current, Marlin will move the Z axis (at homing speed) to the top plus a given extra distance. _Since this intentionally stalls the Z steppers, you should use the minimum current required to move the axis._
 


### PR DESCRIPTION
Videos show up at the bottom of pages once deployed.