### PR TITLE
Remove Invalid VAkE 403D Motherboard

### DIFF
--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -690,8 +690,6 @@
     brief: "Lerdge S (STM32F407VE)"
   - name: LERDGE_X
     brief: "Lerdge X (STM32F407VE)"
-  - name: VAKE403D
-    brief: "VAkE 403D (STM32F446VE)"
   - name: FYSETC_S6
     brief: "FYSETC S6 (STM32F446VE)"
   - name: FYSETC_S6_V2_0


### PR DESCRIPTION
### Description

Remove invalid VAkE 403D motherboard since there were only 10 prototype boards ever made & the project never moved forward.

https://github.com/MarlinFirmware/Marlin/pull/25969