### PR TITLE
Clarify behaviour of M201 and M204 with respect to retraction moves

### DIFF
--- a/_gcode/M201.md
+++ b/_gcode/M201.md
@@ -1,7 +1,7 @@
 ---
 tag: m0201
-title: Print Move Limits
-brief: Set acceleration and frequency limits for print moves.
+title: Print and Travel Move Limits
+brief: Set acceleration and frequency limits for print and travel moves.
 author: thinkyhead
 
 group: motion
@@ -11,6 +11,7 @@ codes: [ M201 ]
 notes:
   - View the current setting with [`M503`](/docs/gcode/M503.html).
   - If `EEPROM_SETTINGS` is enabled, these are saved with [`M500`](/docs/gcode/M500.html), loaded with [`M501`](/docs/gcode/M501.html), and reset with [`M502`](/docs/gcode/M502.html).
+  - Note `M201` does not affect retraction / de-retraction moves. See [`M204 R`](/docs/gcode/M204.html) instead.
 
 parameters:
   -

--- a/_gcode/M204.md
+++ b/_gcode/M204.md
@@ -25,7 +25,7 @@ parameters:
   -
     tag: R
     optional: true
-    description: Retract acceleration. Used for extruder retraction moves.
+    description: Retract acceleration. Used for extruder retraction / de-retraction moves.
     values:
       -
         tag: accel


### PR DESCRIPTION
`M201` affects both print and *travel* movements, but does not affect retraction movements. It has been this way since the birth of Marlin.

Added a clarification to make it clear that de-retraction movements are affected by the same `M204 R` setting as retraction movements.