### PR TITLE
RESTORE_LEVELING_AFTER_G28 is wrongly described

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -802,7 +802,7 @@ Junction Deviation determins the cornering speed. The smaller the value the slow
 
 Use the above formula to calculate the Junction Deviation amount.
 
-See the following sources for detailed explainations on Junction Deviation:
+See the following sources for detailed explanations of Junction Deviation:
 - [JD Explained and Visualized, by Paul Wanamaker](//reprap.org/forum/read.php?1,739819)
 - [Computing JD for Marlin Firmware](//blog.kyneticcnc.com/2018/10/computing-junction-deviation-for-marlin.html)
 - [Improving GRBL: Cornering Algorithm](//onehossshay.wordpress.com/2011/09/24/improving_grbl_cornering_algorithm/)

--- a/_gcode/G028.md
+++ b/_gcode/G028.md
@@ -11,7 +11,7 @@ codes: [ G28 ]
 notes:
   - Homing is required before [`G29`](/docs/gcode/G029.html), [`M48`](/docs/gcode/M048.html), and some other procedures.
   - If homing is needed the LCD will blink the X Y Z indicators.
-  - "  - "`G28` disables bed leveling. Follow with `M420 S` to turn leveling on, or use `ENABLE_LEVELING_AFTER_G28` to automatically keep leveling on after `G28`. Or you can use `RESTORE_LEVELING_AFTER_G28` if you want to restore the state before `G28`. In this case it stays disabled if it was disabled. It will be enabled again if it was enabled.""
+  - "`G28` disables bed leveling. Follow with `M420 S` to turn leveling on, or use `ENABLE_LEVELING_AFTER_G28` to automatically keep leveling on after `G28`. Or you can use `RESTORE_LEVELING_AFTER_G28` if you want to restore the state before `G28`. In this case it stays disabled if it was disabled. It will be enabled again if it was enabled."
 
 parameters:
   -

--- a/_gcode/G028.md
+++ b/_gcode/G028.md
@@ -11,7 +11,10 @@ codes: [ G28 ]
 notes:
   - Homing is required before [`G29`](/docs/gcode/G029.html), [`M48`](/docs/gcode/M048.html), and some other procedures.
   - If homing is needed the LCD will blink the X Y Z indicators.
-  - "`G28` disables bed leveling. Follow with `M420 S` to turn leveling on, or use `ENABLE_LEVELING_AFTER_G28` to automatically keep leveling on after `G28`. Or you can use `RESTORE_LEVELING_AFTER_G28` if you want to restore the state before `G28`. In this case it stays disabled if it was disabled. It will be enabled again if it was enabled."
+  - |
+    By default `G28` disables bed leveling. Follow with `M420 S` to turn leveling on.
+      - With `ENABLE_LEVELING_AFTER_G28` leveling will always be enabled after `G28`.
+      - With `RESTORE_LEVELING_AFTER_G28` leveling is restored to whatever state it was in before `G28`.
 
 parameters:
   -

--- a/_gcode/G028.md
+++ b/_gcode/G028.md
@@ -11,7 +11,7 @@ codes: [ G28 ]
 notes:
   - Homing is required before [`G29`](/docs/gcode/G029.html), [`M48`](/docs/gcode/M048.html), and some other procedures.
   - If homing is needed the LCD will blink the X Y Z indicators.
-  - "`G28` disables bed leveling. Follow with `M420 S` to turn leveling on, or use `RESTORE_LEVELING_AFTER_G28` to automatically keep leveling on after `G28`."
+  - "  - "`G28` disables bed leveling. Follow with `M420 S` to turn leveling on, or use `ENABLE_LEVELING_AFTER_G28` to automatically keep leveling on after `G28`. Or you can use `RESTORE_LEVELING_AFTER_G28` if you want to restore the state before `G28`. In this case it stays disabled if it was disabled. It will be enabled again if it was enabled.""
 
 parameters:
   -


### PR DESCRIPTION
RESTORE_LEVELING_AFTER_G28 is wrongly described as it does not enable autoleveling after G28 in any case