### PR TITLE
update hex regular expression in RGB565 converter tool

### DIFF
--- a/_tools/rgb565/converter.js
+++ b/_tools/rgb565/converter.js
@@ -444,7 +444,7 @@ var bitmap_converter = function() {
         $.each(s.split(','), function(i, s) {
           //console.log("s value:",s);
           var b;
-          if (s.match(/0x[0-9a-f]+(?![0-9x_])/i)) { // Hex
+          if (s.match(/\b0x[0-9a-f]+/i)) { // Hex
             b = parseInt(s.substring(2), 16);
             if (contains_rle16) rledata.push(b);
           } else if (s.match(/[0-9]+/)) // Decimal

--- a/_tools/rgb565/converter.js
+++ b/_tools/rgb565/converter.js
@@ -444,7 +444,7 @@ var bitmap_converter = function() {
         $.each(s.split(','), function(i, s) {
           //console.log("s value:",s);
           var b;
-          if (s.match(/0x[0-9a-f]+/i)) { // Hex
+          if (s.match(/0x[0-9a-f]+(?![0-9x_])/i)) { // Hex
             b = parseInt(s.substring(2), 16);
             if (contains_rle16) rledata.push(b);
           } else if (s.match(/[0-9]+/)) // Decimal


### PR DESCRIPTION
 I missed a bug in processing pasted rle16 encoded data

the code `if (s.match(/0x[0-9a-f]+/i)) { // Hex`  is meant to match hexadecimal encoded strings only eg 0x12FE

It doesn't trigger on "marlin_logo_195x59x16_rle16" which is what I did my testing on.

But it does match on "marlin_logo_240x250x16_rle16"   Causing the image to be incorrectly decoded

Updated the RE to `/0x[0-9a-f]+(?![0-9x_])/i`  to exclude the false positive.



