### PR TITLE
Fix GitHub Contributor Links

### DIFF
--- a/_gcode/G060.md
+++ b/_gcode/G060.md
@@ -3,7 +3,7 @@ tag: g060
 title: Save Current Position
 brief: Save current position to specified slot
 author: shitcreek
-contrib: [ Hans007a, TwoRedCells, thinkyhead ]
+contrib: Hans007a, TwoRedCells, thinkyhead
 codes: [ G60 ]
 related: [ G61 ]
 

--- a/_gcode/G061.md
+++ b/_gcode/G061.md
@@ -3,7 +3,7 @@ tag: g061
 title: Return to Saved Position
 brief: Return to saved position of specified slot
 author: shitcreek
-contrib: [ Hans007a, thinkyhead ]
+contrib: Hans007a, thinkyhead
 codes: [ G61 ]
 related: [ G60 ]
 

--- a/_gcode/M043-T.md
+++ b/_gcode/M043-T.md
@@ -3,7 +3,7 @@ tag: m0043b
 title: Toggle Pins
 brief: Get information about pins.
 author: thinkyhead
-contrib: [ TwoRedCells ]
+contrib: TwoRedCells
 experimental: true
 requires: PINS_DEBUGGING
 group: debug


### PR DESCRIPTION
### Description

Fix GitHub contributor links.

Broken links can be seen at [G60 - Save Current Position](https://marlinfw.org/docs/gcode/G060.html) for example:
<img width="176" alt="image" src="https://github.com/MarlinFirmware/MarlinDocumentation/assets/13375512/a3455771-94b8-41af-91e8-1ebb980600a8">
