### PR TITLE
Update M593.md with correct layer var for PRUSA

### DIFF
--- a/_gcode/M593.md
+++ b/_gcode/M593.md
@@ -80,7 +80,7 @@ Use a slicer that provides custom G-code macros for layer change. For example yo
 
 - In *Prusa Slicer* you'll enable **Spiral vase**. Then add the following to your **Printer Settings > After layer change G-code** to run a test range of 15Hz to 60Hz:
   ```
-  M593 F{(layer_num < 2 ? 0 : 15 + 45.0 * (layer_num - 2) / 297)} ; Hz Input Shaping Test
+  M593 F{(layer_z < 2 ? 0 : 15 + 45.0 * (layer_z - 2) / 297)} ; Hz Input Shaping Test
   ```
 
 - In *Cura*, you'll first need to add the .py file in [this repository](//www.github.com/dsdanielko/cura-ringing-tower-script/) to your Cura "scripts" folder. Reopen Cura, enable **Spiralize Outer Contour** and set **Minimum Layer Time** to 0. Then go to **Extensions > Post Processing > Modify G-Code**. Click **Add a script** in the window that opens and use the dropdown menu to find **Input Shaping**. Make sure the **Motion planning type** dropdown is set to **M593**. The default frequency settings will let you test a range of 15Hz to 60Hz.


### PR DESCRIPTION
As of Slicer 2.7.0 and firmware 5.1.0 (MK4) the var name for layer number is layer_z