### PR TITLE
📝 Update help links

### DIFF
--- a/_basics/reporting_bugs.md
+++ b/_basics/reporting_bugs.md
@@ -68,6 +68,9 @@ In addition to following the guidelines above, we ask that you follow a thorough
 ## Links
 
   - [Issue Queue](//github.com/MarlinFirmware/Marlin/issues)
-  - [Post a New Issue](//github.com/MarlinFirmware/Marlin/issues/new)
-  - [Bug Fix branch](//github.com/MarlinFirmware/Marlin/tree/bugfix-1.1.x)
-  - [RepRap forums](//forums.reprap.org/)
+  - [Post a New Issue](//github.com/MarlinFirmware/Marlin/issues/new?labels=Bug%3A+Potential+%3F&template=bug_report.yml&title=%5BBUG%5D+%28bug+summary%29)
+  - [Bug Fix branch](//github.com/MarlinFirmware/Marlin/tree/bugfix-2.1.x)
+  - [MarlinFirmware on Discord](//discord.gg/n5NJ59y) - Realtime chat with users and developers
+  - [Marlin Firmware](//www.facebook.com/groups/1049718498464482/) and [Marlin Firmware for 3D Printers](//www.facebook.com/groups/3Dtechtalk/) Facebook Groups
+  - [Marlin Forum](//forums.reprap.org/list.php?415) at RepRap.org
+  - [Marlin YouTube Videos](//youtube.com/results?search_query=marlin+firmware)

--- a/_development/contributing.md
+++ b/_development/contributing.md
@@ -28,7 +28,7 @@ Your sponsorship accelerates development, testing, and advancement of the most a
 
 ### Report bugs
 - Use the community links below for help with configuration and troubleshooting.
-- Submit your **Confirmed Bugs** to the [Issue Queue](//github.com/MarlinFirmware/Marlin/issues/new?template=bug_report.yml&title=%5BBUG%5D+%28bug+summary%29). Search the Issue Queue first!
+- Submit your **Confirmed Bugs** to the [Issue Queue](//github.com/MarlinFirmware/Marlin/issues/new?labels=Bug%3A+Potential+%3F&template=bug_report.yml&title=%5BBUG%5D+%28bug+summary%29). Search the Issue Queue first!
 
 ### Request features
 - Submit your **Feature Requests** to the [Issue Queue](//github.com/MarlinFirmware/Marlin/issues/new?labels=T%3A+Feature+Request&template=feature_request.yml&title=%5BFR%5D+%28feature+summary%29). Search the Issue Queue first!

--- a/_development/feature_request.md
+++ b/_development/feature_request.md
@@ -24,7 +24,7 @@ Marlin has _a lot_ of features, and there are several more in development, but w
 
 # Submitting a Feature Request
 
-Go to the Marlin project page to [Open a New Issue](//github.com/MarlinFirmware/Marlin/issues/new) and follow these guidelines:
+Go to the Marlin project page to [Open a Feature Request](//github.com/MarlinFirmware/Marlin/issues/new?labels=T%3A+Feature+Request&template=feature_request.yml&title=%5BFR%5D+%28feature+summary%29) and follow these guidelines:
 
 - Prefix the title with **'[Feature Request]'** or its short form, **'[FR]'**.
 - Keep the title short and to the point. A good example would be:


### PR DESCRIPTION
### Description

### `reporting_bugs.md` fixes
- Fix "Issue Queue" link so it creates a new bug report using the template instead of being completely blank
- Update "Bug Fix branch" link to `bugfix-2.1.x`
- Copy block of help links from `contributing.md` for consistency

### `contributing.md` fixes
- Add label to URL

### `feature_request.md` fixes
- Rename "Open a New Issue" link to "Open a Feature Request" & fix link so it creates a new feature request using the template instead of being completely blank