### PR TITLE
Add probe location examples

### DIFF
--- a/_gcode/M851.md
+++ b/_gcode/M851.md
@@ -21,20 +21,36 @@ notes: |
         - (version 2.x)
           - `NOZZLE_TO_PROBE_OFFSET`
 
-        Positions:
-        - X offset: -left  +right [of the nozzle]
-        - Y offset: -front +behind [the nozzle]
-        - Z offset: -below +above [the nozzle]
+        X and Y offset:
+          Use a caliper or ruler to measure the distance from the tip of
+          the Nozzle to the center-point of the Probe in the X and Y axes.
+
+        Z offset:
+        - For the Z offset use your best known value and adjust at runtime.
+        - Common probes trigger below the nozzle and have negative values for Z offset.
+        - Probes triggering above the nozzle height are uncommon but do exist. When using probes such as this, carefully set `Z_CLEARANCE_DEPLOY_PROBE` and `Z_CLEARANCE_BETWEEN_PROBES` to avoid collisions during probing.
+
+        Assuming the typical work area orientation:
+        - Probe to RIGHT of the Nozzle has a Positive X offset
+        - Probe to LEFT  of the Nozzle has a Negative X offset
+        - Probe in BACK  of the Nozzle has a Positive Y offset
+        - Probe in FRONT of the Nozzle has a Negative Y offset
+
+        Some examples:
+        - `#define NOZZLE_TO_PROBE_OFFSET { 10, 10, -1 }   // Example "1"`
+        - `#define NOZZLE_TO_PROBE_OFFSET {-10,  5, -1 }   // Example "2"`
+        - `#define NOZZLE_TO_PROBE_OFFSET {  5, -5, -1 }   // Example "3"`
+        - `#define NOZZLE_TO_PROBE_OFFSET {-15,-10, -1 }   // Example "4"`
 
         ```
            +-- BACK ---+
-           |           |
-         L |    (+) P  | R <-- probe (20,20)
-         E |           | I
-         F | (-) N (+) | G <-- nozzle (10,10)
-         T |           | H
-           |    (-)    | T
-           |           |
+           |    [+]    |
+         L |        1  | R <-- Example "1" (right+,  back+)
+         E |  2        | I <-- Example "2" ( left-,  back+)
+         F |[-]  N  [+]| G <-- Nozzle
+         T |       3   | H <-- Example "3" (right+, front-)
+           | 4         | T <-- Example "4" ( left-, front-)
+           |    [-]    |
            O-- FRONT --+
          (0,0)
         ```


### PR DESCRIPTION
Ported over from ["Nozzle-to-Probe offsets" section](https://github.com/MarlinFirmware/Marlin/blob/68ab7f6bb7d93ed24054b033334c5821ea4e4cbf/Marlin/Configuration.h#L1527-L1567) in `Configuration.h`