### PR TITLE
Fix Orca Slicer & Bambu Studio origins

### DIFF
--- a/_basics/introduction.md
+++ b/_basics/introduction.md
@@ -74,8 +74,8 @@ A high degree of knowledge is needed to model complex objects like a [T-Rex Skul
 Slicers prepare a solid 3D model by dividing it up into thin slices (layers). In the process it generates the [G-code](//en.wikipedia.org/wiki/G-code) that tells the printer in minute detail how to reproduce the model. There are many slicers to choose from, including:
 
 - [PrůšaSlicer](//www.prusa3d.com/prusaslicer/) is a very capable, cutting-edge, free, open source slicer based on Slic3r.
-- [Orca Slicer](//github.com/SoftFever/OrcaSlicer) is a popular fork of PrůšaSlicer with some refinements.
-- [Bambu Studio](//github.com/bambulab/BambuStudio) is a fork of Orca and PrůšaSlicer introduced in 2023 by Bambu Labs.
+- [Bambu Studio](//github.com/bambulab/BambuStudio) is a fork of PrůšaSlicer introduced in 2023 by Bambu Labs.
+- [Orca Slicer](//github.com/SoftFever/OrcaSlicer) is a popular fork of Bambu Studio with some refinements.
 - [Cura](//ultimaker.com/en/products/cura-software) is a popular free slicer that's included with many printers and often re-branded.
 - [Slic3r](//slic3r.org/) is one of the first slicers and is the basis for many others.
 - [Simplify3D](//www.simplify3d.com/) is a solid commercial offering with a simplified interface.


### PR DESCRIPTION
### Description

Follow up to 4fcd86a

Orca Slicer is a fork of Bambu Studio, not the other way around. Bambu Studio is a fork of PrusaSlicer.

Also, it's "PrusaSlicer", not "PrůšaSlicer", but I didn't fix that here:

Sources:
- [PrusaSlicer project page on Prusa3D.com](https://www.prusa3d.com/page/prusaslicer_424/)
- [PrusaSlicer readme on GitHub](https://github.com/prusa3d/PrusaSlicer/blob/master/README.md)
- About dialog in PrusaSlicer:
  <img width="50%" alt="image" src="https://github.com/MarlinFirmware/MarlinDocumentation/assets/13375512/35a18313-259d-40e4-948c-8e8e82022dd4">