### PR TITLE
Update M600.md to mention Configuration_adv.h

### DIFF
--- a/_gcode/M600.md
+++ b/_gcode/M600.md
@@ -91,7 +91,7 @@ parameters:
 
 examples:
 -
-  pre: With no parameters [`M600`](/docs/gcode/M600.html) uses the settings in `Configuration.h`.
+  pre: With no parameters [`M600`](/docs/gcode/M600.html) uses the settings in `Configuration_adv.h`.
   code: M600 ; execute filament change
 -
   pre: 'To set the change position:'

--- a/_gcode/M600.md
+++ b/_gcode/M600.md
@@ -12,91 +12,71 @@ group: filament
 codes: [ M600 ]
 
 notes:
-- Requires `ADVANCED_PAUSE_FEATURE`.
-- The settings for this command can be found in `Configuration_adv.h`. At this time [`M600`](/docs/gcode/M600.html) requires an LCD controller.
+- Configuration settings for `M600` are in `Configuration_adv.h`.
+- This command requires an LCD controller or host action commands.
 
 parameters:
--
-  tag: T
+- tag: T
   optional: true
   description: Target extruder
   values:
-  -
-    tag: index
+  - tag: index
     type: int
--
-  tag: E
+- tag: E
   optional: true
   description: Retract before moving to change position (negative, default `PAUSE_PARK_RETRACT_LENGTH`)
   values:
-  -
-    tag: pos
+  - tag: pos
     type: float
--
-  tag: U
+- tag: U
   optional: true
   description: Amount of retraction for unload (negative)
   values:
-  -
-    tag: pos
+  - tag: pos
     type: float
--
-  tag: L
+- tag: L
   optional: true
   description: Load length, longer for bowden (negative)
   values:
-  -
-    tag: pos
+  - tag: pos
     type: float
--
-  tag: X
+- tag: X
   optional: true
   description: X position for filament change
   values:
-  -
-    tag: pos
+  - tag: pos
     type: float
--
-  tag: Y
+- tag: Y
   optional: true
   description: Y position for filament change
   values:
-  -
-    tag: pos
+  - tag: pos
     type: float
--
-  tag: Z
+- tag: Z
   optional: true
   description: Z relative lift for filament change position
   values:
-  -
-    tag: pos
+  - tag: pos
     type: float
--
-  tag: B
+- tag: B
   optional: true
   description: Number of beeps to alert user of filament change (default `FILAMENT_CHANGE_ALERT_BEEPS`)
   values:
-  -
-    tag: beeps
+  - tag: beeps
     type: int
--
-  tag: R
+- tag: R
   optional: true
   description: "Resume temperature. (AUTOTEMP: the min auto-temperature.)"
   values:
-  -
-    tag: temp
+  - tag: temp
     type: int
 
 examples:
--
-  pre: With no parameters [`M600`](/docs/gcode/M600.html) uses the settings in `Configuration_adv.h`.
-  code: M600 ; execute filament change
--
-  pre: 'To set the change position:'
-  code: M600 X10 Y15 Z5 ; Do filament change at X:10, Y:15 and Z:+5 from current
+- pre: With no parameters use the configured settings
+  code: M600
+- pre: Do filament change at X10 Y15 with 5mm Z raise
+  code: M600 X10 Y15 Z5
 
 ---
 
-The [`M600`](/docs/gcode/M600.html) command initiates the filament change procedure. The basic procedure will move the print head away from the print, eject the filament, wait for new filament to be inserted and the user to confirm, load and prime the filament, and continue with the print. [`M600`](/docs/gcode/M600.html) may be initiated automatically if a filament runout sensor is installed.
+The `M600` command initiates the filament change procedure. The basic procedure will move the print head away from the print, eject the filament, wait for new filament to be inserted and the user to confirm, load and prime the filament, and continue with the print. `M600` may be initiated automatically if a filament runout sensor is installed.


### PR DESCRIPTION
There is still Configuration.h: _With no parameters [M600](https://marlinfw.org/docs/gcode/M600.html) uses the settings in **Configuration.h**._

Fix it