### PR TITLE
Update G042.md with P bool command

### DIFF
--- a/_gcode/G042.md
+++ b/_gcode/G042.md
@@ -32,6 +32,12 @@ parameters:
   values:
   - tag: rate
     type: float
+    
+- tag: P
+  optional: true
+  description: If `HAS_PROBE_XY_OFFSET`, add the probe's XY offset to destination. This moves the probe to position in place of nozzle.
+  values:
+  - type: bool
 
 examples:
 
@@ -41,6 +47,7 @@ examples:
     - G42 I4 J4 ; center
     - G42 I4 J8 ; back center
     - G42 I8 J8 ; back right
+    - G42 I2 J2 P ; moves probe to point instead of nozzle
 
 ---
 

--- a/_gcode/G042.md
+++ b/_gcode/G042.md
@@ -35,9 +35,9 @@ parameters:
     
 - tag: P
   optional: true
-  description: If `HAS_PROBE_XY_OFFSET`, add the probe's XY offset to destination. This moves the probe to position in place of nozzle.
+  description: If there is a probe, move it to the given position.
   values:
-  - type: bool
+  - type: flag
 
 examples:
 


### PR DESCRIPTION
G42 has this code
```y
    #if HAS_PROBE_XY_OFFSET
      if (parser.boolval('P')) {
        if (hasI) destination.x -= probe.offset_xy.x;
        if (hasJ) destination.y -= probe.offset_xy.y;
      }
    #endif
```

so this documentation should be updated to include this bool type parameter.