### PR TITLE
📝 Add new boards, complete “since” version

### DIFF
--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -199,6 +199,9 @@
   - name: KODAMA_BARDO
     brief: Kodama Bardo V1.x (as found in the Kodama Trinus)
     since: 2.1.3
+  - name: DAGOMA_D6
+    brief: Dagoma D6 (as found in the Dagoma DiscoUltimate V2 TMC)
+    since: 2.1.3
 
 #
 # RAMBo and derivatives

--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -851,8 +851,8 @@
     brief: FYSETC Spider King407 (STM32F407ZG)
   - name: MKS_SKIPR_V1
     brief: MKS SKIPR v1.0 all-in-one board (STM32F407VE)
-  - name: TRONXY_V10
-    brief: TRONXY V10 (STM32F446ZE)
+  - name: TRONXY_CXY_446_V10
+    brief: TRONXY CXY-446-V10-220413/CXY-V6-191121 (STM32F446ZE)
   - name: CREALITY_F401RE
     brief: Creality CR4NS200141C13 (STM32F401RE) as found in the Ender-5 S1
     since: 2.1.3

--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -1018,7 +1018,7 @@
 - group: Marlin Simulator
   long: |
     Marlin includes a built-in Simulator HAL (`NATIVE_SIM`) that runs on Windows, macOS, or Linux for debugging and experimentation.
-    It can simulate a standard Graphical LCD or a TFT Color display.
+    It can simulate a Character-based LCD, standard Graphical LCD, or a TFT Color display.
   boards:
   - name: SIMULATED
     brief: Simulated cartesian printer built with Dear ImGui, SDL, and OpenGL.

--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -116,8 +116,11 @@
     brief: MKS BASE 1.0 with Heroic HR4982 stepper drivers
     since: 1.1.9
   - name: MKS_GEN_13
-    brief: MKS GEN v1.3 or 1.4. Originally supported as `BOARD_MKS_13` since `1.1.0-RC6`.
+    brief: MKS GEN v1.3 or 1.4.
     since: 1.1.9
+    old:
+    - name: MKS_13
+      since: 1.1.0-RC6
   - name: MKS_GEN_L
     brief: MKS GEN L
     since: 1.1.7
@@ -200,8 +203,11 @@
     brief: Creality CR10S, CR20, and CR-X
     since: 2.0.0
   - name: DAGOMA_F5
-    brief: Dagoma F5. Originally supported as `BOARD_RAMPS_DAGOMA` since `2.0.0`.
+    brief: Dagoma F5.
     since: 2.0.8
+    old:
+    - name: RAMPS_DAGOMA
+      since: 2.0.0
   - name: FYSETC_F6_13
     brief: FYSETC F6 1.3
     since: 2.0.0
@@ -601,14 +607,23 @@
     brief: GMARSH X6, revision 1 prototype
     since: 2.0.0
   - name: BTT_SKR_V1_1
-    brief: BigTreeTech SKR v1.1. Originally supported as `BOARD_BIGTREE_SKR_V1_1` since `2.0.0`.
+    brief: BigTreeTech SKR v1.1.
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_V1_1
+      since: 2.0.0
   - name: BTT_SKR_V1_3
-    brief: BigTreeTech SKR v1.3. Originally supported as `BOARD_BIGTREE_SKR_V1_3` since `2.0.0`.
+    brief: BigTreeTech SKR v1.3.
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_V1_3
+      since: 2.0.0
   - name: BTT_SKR_V1_4
-    brief: BigTreeTech SKR v1.4. Originally supported as `BOARD_BIGTREE_SKR_V1_4` since `2.0.1`.
+    brief: BigTreeTech SKR v1.4.
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_V1_4
+      since: 2.0.1
   - name: EMOTRONIC
     brief: eMotion-Tech eMotronic
     since: 2.0.9.5/2.1.1
@@ -645,8 +660,11 @@
     brief: TH3D EZBoard v1.0
     since: 2.0.0
   - name: BTT_SKR_V1_4_TURBO
-    brief: BigTreeTech SKR v1.4 TURBO. Originally supported as `BOARD_BIGTREE_SKR_V1_4_TURBO` since `2.0.2`.
+    brief: BigTreeTech SKR v1.4 TURBO.
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_V1_4_TURBO
+      since: 2.0.2
   - name: MKS_SGEN_L_V2
     brief: MKS SGEN_L V2
     since: 2.0.7
@@ -783,8 +801,11 @@
     brief: BigTreeTech Manta E3 EZ V1.0 (STM32G0B1RE)
     since: 2.1.2.1
   - name: BTT_MANTA_M4P_V2_1
-    brief: BigTreeTech Manta M4P V2.1 (STM32G0B0RE). Originally supported as `BOARD_BTT_MANTA_M4P_V1_0` since `2.1.2.1`.
+    brief: BigTreeTech Manta M4P V2.1 (STM32G0B0RE).
     since: 2.1.2.2
+    old:
+    - name: BTT_MANTA_M4P_V1_0
+      since: 2.1.2.1
   - name: BTT_MANTA_M5P_V1_0
     brief: BigTreeTech Manta M5P V1.0 (STM32G0B1RE)
     since: 2.1.2.1
@@ -872,8 +893,11 @@
     brief: MKS Robin E3P (STM32F103VE)
     since: 2.0.7
   - name: BTT_SKR_MINI_V1_1
-    brief: BigTreeTech SKR Mini v1.1 (STM32F103RC). Originally supported as `BOARD_BIGTREE_SKR_MINI_V1_1` since `2.0.0`.
+    brief: BigTreeTech SKR Mini v1.1 (STM32F103RC).
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_MINI_V1_1
+      since: 2.0.0
   - name: BTT_SKR_MINI_E3_V1_0
     brief: BigTreeTech SKR Mini E3 (STM32F103RC)
     since: 2.0.0
@@ -887,8 +911,11 @@
     brief: BigTreeTech SKR Mini MZ V1.0 (STM32F103RC)
     since: 2.0.8
   - name: BTT_SKR_E3_DIP
-    brief: BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE). Originally supported as `BOARD_BIGTREE_SKR_E3_DIP` since `2.0.0`.
+    brief: BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE).
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_E3_DIP
+      since: 2.0.0
   - name: BTT_SKR_CR6
     brief: BigTreeTech SKR CR6 v1.0 (STM32F103RE)
     since: 2.0.8
@@ -1047,14 +1074,20 @@
     brief: Arm'ed STM32F4-based controller
     since: 2.0.0
   - name: RUMBA32_V1_0
-    brief: RUMBA32 STM32F446VE based controller from Aus3D. Originally supported as `BOARD_RUMBA32` since `2.0.0`.
+    brief: RUMBA32 STM32F446VE based controller from Aus3D.
     since: 2.0.6
+    old:
+    - name: RUMBA32
+      since: 2.0.0
   - name: RUMBA32_V1_1
     brief: RUMBA32 STM32F446VE based controller from Aus3D
     since: 2.0.6
   - name: RUMBA32_MKS
-    brief: RUMBA32 STM32F446VE based controller from Makerbase. Originally supported as `BOARD_RUMBA32` since `2.0.0`.
+    brief: RUMBA32 STM32F446VE based controller from Makerbase.
     since: 2.0.4
+    old:
+    - name: RUMBA32
+      since: 2.0.0
   - name: RUMBA32_BTT
     brief: RUMBA32 STM32F446VE based controller from BIGTREETECH
     since: 2.0.9.2
@@ -1068,23 +1101,35 @@
     brief: BigTreeTech SKR Mini E3 V3.0.1 (STM32F401RC)
     since: 2.1.2
   - name: BTT_SKR_PRO_V1_1
-    brief: BigTreeTech SKR Pro v1.1 (STM32F407ZG). Originally supported as `BOARD_BIGTREE_SKR_PRO_V1_1` since `2.0.0`.
+    brief: BigTreeTech SKR Pro v1.1 (STM32F407ZG).
     since: 2.0.4
+    old:
+    - name: BIGTREE_SKR_PRO_V1_1
+      since: 2.0.0
   - name: BTT_SKR_PRO_V1_2
     brief: BigTreeTech SKR Pro v1.2 (STM32F407ZG)
     since: 2.0.6
   - name: BTT_BTT002_V1_0
-    brief: BigTreeTech BTT002 v1.0 (STM32F407VG). Originally supported as `BOARD_BIGTREE_BTT002_V1_0` since `2.0.0`.
+    brief: BigTreeTech BTT002 v1.0 (STM32F407VG).
     since: 2.0.4
+    old:
+    - name: BIGTREE_BTT002_V1_0
+      since: 2.0.0
   - name: BTT_E3_RRF
     brief: BigTreeTech E3 RRF (STM32F407VG)
     since: 2.0.8
   - name: BTT_SKR_V2_0_REV_A
-    brief: BigTreeTech SKR v2.0 Rev A (STM32F407VG). Originally supported as `BOARD_BTT_SKR_V2_0` since `2.0.8`.
+    brief: BigTreeTech SKR v2.0 Rev A (STM32F407VG).
     since: 2.0.8.1
+    old:
+    - name: BTT_SKR_V2_0
+      since: 2.0.8
   - name: BTT_SKR_V2_0_REV_B
-    brief: BigTreeTech SKR v2.0 Rev B (STM32F407VG/STM32F429VG). Originally supported as `BOARD_BTT_SKR_V2_0` since `2.0.8`.
+    brief: BigTreeTech SKR v2.0 Rev B (STM32F407VG/STM32F429VG).
     since: 2.0.8.1
+    old:
+    - name: BTT_SKR_V2_0
+      since: 2.0.8
   - name: BTT_GTR_V1_0
     brief: BigTreeTech GTR v1.0 (STM32F407IGT)
     since: 2.0.4
@@ -1131,11 +1176,17 @@
     brief: MKS Robin Nano V3.1 (STM32F407VE)
     since: 2.0.9.4
   - name: MKS_MONSTER8_V1
-    brief: MKS Monster8 V1 (STM32F407VE). Originally supported as `BOARD_MKS_MONSTER8` since `2.0.9.2`.
+    brief: MKS Monster8 V1 (STM32F407VE).
     since: 2.0.9.5/2.1.1
+    old:
+    - name: MKS_MONSTER8
+      since: 2.0.9.2
   - name: MKS_MONSTER8_V2
-    brief: MKS Monster8 V2 (STM32F407VE). Originally supported as `BOARD_MKS_MONSTER8` since `2.0.9.2`.
+    brief: MKS Monster8 V2 (STM32F407VE).
     since: 2.0.9.5/2.1.1
+    old:
+    - name: MKS_MONSTER8
+      since: 2.0.9.2
   - name: ANET_ET4
     brief: ANET ET4 V1.x (STM32F407VG)
     since: 2.0.8
@@ -1146,8 +1197,11 @@
     brief: FYSETC Cheetah V2.0 (STM32F401RC)
     since: 2.0.8
   - name: TH3D_EZBOARD_V2
-    brief: TH3D EZBoard v2.0 (STM32F405RG). Originally supported as `BOARD_TH3D_EZBOARD_LITE_V2` since `2.0.9.2`.
+    brief: TH3D EZBoard v2.0 (STM32F405RG).
     since: 2.0.9.3
+    old:
+    - name: TH3D_EZBOARD_LITE_V2
+      since: 2.0.9.2
   - name: OPULO_LUMEN_REV3
     brief: Opulo Lumen PnP Controller REV3 (STM32F407VE / STM32F407VG)
     since: 2.0.9.5/2.1.1
@@ -1179,9 +1233,11 @@
     brief: MKS SKIPR v1.0 all-in-one board (STM32F407VE)
     since: 2.1.2
   - name: TRONXY_CXY_446_V10
-    oldname: TRONXY_V10
-    brief: TRONXY CXY-446-V10-220413/CXY-V6-191121 (STM32F446ZE). `BOARD_TRONXY_V10` prior to `2.1.3`.
+    brief: TRONXY CXY-446-V10-220413/CXY-V6-191121 (STM32F446ZE)
     since: 2.1.3
+    old:
+    - name: TRONXY_V10
+      since: 2.1.2
   - name: CREALITY_F401RE
     brief: Creality CR4NS200141C13 (STM32F401RE) as found in the Ender-5 S1
     since: 2.1.3
@@ -1246,11 +1302,17 @@
     brief: ST NUCLEO-F767ZI Dev Board
     since: 2.0.7.2
   - name: BTT_SKR_SE_BX_V2
-    brief: BigTreeTech SKR SE BX V2.0 (STM32H743II). Originally supported as `BOARD_BTT_SKR_SE_BX` since `2.0.8`.
+    brief: BigTreeTech SKR SE BX V2.0 (STM32H743II).
     since: 2.0.9.5/2.1.1
+    old:
+    - name: BTT_SKR_SE_BX
+      since: 2.0.8
   - name: BTT_SKR_SE_BX_V3
-    brief: BigTreeTech SKR SE BX V3.0 (STM32H743II). Originally supported as `BOARD_BTT_SKR_SE_BX` since `2.0.8`.
+    brief: BigTreeTech SKR SE BX V3.0 (STM32H743II).
     since: 2.0.9.5/2.1.1
+    old:
+    - name: BTT_SKR_SE_BX
+      since: 2.0.8
   - name: BTT_SKR_V3_0
     brief: BigTreeTech SKR V3.0 (STM32H743VI / STM32H723VG)
     since: 2.0.9.4
@@ -1380,5 +1442,8 @@
     It can simulate a Character-based LCD, standard Graphical LCD, or a TFT Color display.
   boards:
   - name: SIMULATED
-    brief: Simulated cartesian printer built with Dear ImGui, SDL, and OpenGL. Originally supported as `BOARD_LINUX_RAMPS` since `2.0.0`.
+    brief: Simulated cartesian printer built with Dear ImGui, SDL, and OpenGL.
     since: 2.1.2.1
+    old:
+    - name: LINUX_RAMPS
+      since: 2.0.0

--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -10,36 +10,52 @@
   boards:
   - name: RAMPS_OLD
     brief: MEGA/RAMPS up to 1.2
+    since: 1.0.1
   - name: RAMPS_13_EFB
     brief: "RAMPS 1.3 (Power outputs: Hotend, Fan, Bed)"
+    since: 1.0.1
   - name: RAMPS_13_EEB
     brief: "RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Bed)"
+    since: 1.0.1
   - name: RAMPS_13_EFF
     brief: "RAMPS 1.3 (Power outputs: Hotend, Fan0, Fan1)"
+    since: 1.0.1
   - name: RAMPS_13_EEF
     brief: "RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Fan)"
+    since: 1.0.1
   - name: RAMPS_13_SF
     brief: "RAMPS 1.3 (Power outputs: Spindle, Controller Fan)"
+    since: 1.1.0-RC2
   - name: RAMPS_14_EFB
     brief: "RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)"
+    since: 1.1.0-RC3
   - name: RAMPS_14_EEB
     brief: "RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)"
+    since: 1.1.0-RC3
   - name: RAMPS_14_EFF
     brief: "RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)"
+    since: 1.1.0-RC3
   - name: RAMPS_14_EEF
     brief: "RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)"
+    since: 1.1.0-RC3
   - name: RAMPS_14_SF
     brief: "RAMPS 1.4 (Power outputs: Spindle, Controller Fan)"
+    since: 1.1.0-RC3
   - name: RAMPS_PLUS_EFB
     brief: "RAMPS Plus 3DYMY (Power outputs: Hotend, Fan, Bed)"
+    since: 1.1.7
   - name: RAMPS_PLUS_EEB
     brief: "RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Bed)"
+    since: 1.1.7
   - name: RAMPS_PLUS_EFF
     brief: "RAMPS Plus 3DYMY (Power outputs: Hotend, Fan0, Fan1)"
+    since: 1.1.7
   - name: RAMPS_PLUS_EEF
     brief: "RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Fan)"
+    since: 1.1.7
   - name: RAMPS_PLUS_SF
     brief: "RAMPS Plus 3DYMY (Power outputs: Spindle, Controller Fan)"
+    since: 1.1.7
   - name: RAMPS_BTT_16_PLUS_EFB
     brief: "RAMPS 1.6+ (Power outputs: Hotend, Fan, Bed)"
     since: 2.1.3
@@ -65,134 +81,199 @@
   boards:
   - name: 3DRAG
     brief: 3Drag Controller
+    since: 1.0.1
   - name: K8200
     brief: Velleman K8200 Controller (derived from 3Drag Controller)
+    since: 1.1.0-RC2
   - name: K8400
     brief: Velleman K8400 Controller (derived from 3Drag Controller)
+    since: 1.1.0-RC7
   - name: K8600
     brief: Velleman K8600 Controller (Vertex Nano)
+    since: 2.0.6
   - name: K8800
     brief: Velleman K8800 Controller (Vertex Delta)
+    since: 2.0.7
   - name: BAM_DICE
     brief: 2PrintBeta BAM&DICE with STK drivers
+    since: 1.1.0-RC2
   - name: BAM_DICE_DUE
     brief: 2PrintBeta BAM&DICE Due with STK drivers
+    since: 1.1.0-RC2
   - name: MKS_BASE
     brief: MKS BASE v1.0
+    since: 1.1.0-RC2
   - name: MKS_BASE_14
     brief: MKS BASE v1.4 with Allegro A4982 stepper drivers
+    since: 2.0.0
   - name: MKS_BASE_15
     brief: MKS BASE v1.5 with Allegro A4982 stepper drivers
+    since: 1.1.9
   - name: MKS_BASE_16
     brief: MKS BASE v1.6 with Allegro A4982 stepper drivers
+    since: 2.0.4
   - name: MKS_BASE_HEROIC
     brief: MKS BASE 1.0 with Heroic HR4982 stepper drivers
+    since: 1.1.9
   - name: MKS_GEN_13
     brief: MKS GEN v1.3 or 1.4
+    since: 1.1.9
   - name: MKS_GEN_L
     brief: MKS GEN L
+    since: 1.1.7
   - name: KFB_2
     brief: BigTreeTech or BIQU KFB2.0
+    since: 2.0.0
   - name: ZRIB_V20
     brief: zrib V2.0 (Chinese RAMPS replica)
+    since: 1.1.3
   - name: ZRIB_V52
     brief: zrib V5.2 (Chinese RAMPS replica)
+    since: 2.0.8
   - name: FELIX2
     brief: Felix 2.0+ Electronics Board (RAMPS like)
+    since: 1.1.0-RC2
   - name: RIGIDBOARD
     brief: Invent-A-Part RigidBoard
+    since: 1.1.0-RC2
   - name: RIGIDBOARD_V2
     brief: Invent-A-Part RigidBoard V2
+    since: 1.1.0-RC7
   - name: SAINSMART_2IN1
     brief: Sainsmart 2-in-1 board
+    since: 1.1.0-RC5
   - name: ULTIMAKER
     brief: Ultimaker
+    since: 1.0.1
   - name: ULTIMAKER_OLD
     brief: Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+    since: 1.0.1
   - name: AZTEEG_X3
     brief: Azteeg X3
+    since: 1.0.1
   - name: AZTEEG_X3_PRO
     brief: Azteeg X3 Pro
+    since: 1.0.1
   - name: ULTIMAIN_2
     brief: Ultimainboard 2.x (Uses TEMP_SENSOR 20)
+    since: 1.0.1
   - name: RUMBA
     brief: Rumba
+    since: 1.0.1
   - name: RUMBA_RAISE3D
     brief: Raise3D N series Rumba derivative
+    since: 2.0.0
   - name: RL200
     brief: Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
+    since: 2.0.0
   - name: FORMBOT_TREX2PLUS
     brief: Formbot T-Rex 2 Plus
+    since: 2.0.0
   - name: FORMBOT_TREX3
     brief: Formbot T-Rex 3
+    since: 2.0.0
   - name: FORMBOT_RAPTOR
     brief: Formbot Raptor
+    since: 2.0.0
   - name: FORMBOT_RAPTOR2
     brief: Formbot Raptor 2
+    since: 2.0.0
   - name: BQ_ZUM_MEGA_3D
     brief: bq ZUM Mega 3D
+    since: 1.1.0-RC4
   - name: MAKEBOARD_MINI
     brief: MakeBoard Mini v2.1.2 by MicroMake
+    since: 1.1.7
   - name: TRIGORILLA_13
     brief: TriGorilla Anycubic version 1.3-based on RAMPS EFB
+    since: 1.1.9
   - name: TRIGORILLA_14
     brief: ... Ver 1.4
+    since: 1.1.9
   - name: TRIGORILLA_14_11
     brief: ... Rev 1.1 (new servo pin order)
+    since: 2.0.0
   - name: RAMPS_ENDER_4
     brief: Creality Ender-4 and CR-8
+    since: 1.1.9
   - name: RAMPS_CREALITY
     brief: Creality CR10S, CR20, and CR-X
+    since: 2.0.0
   - name: DAGOMA_F5
     brief: Dagoma F5
+    since: 2.0.8
   - name: FYSETC_F6_13
     brief: FYSETC F6 1.3
+    since: 2.0.0
   - name: FYSETC_F6_14
     brief: FYSETC F6 1.4
+    since: 2.0.2
   - name: DUPLICATOR_I3_PLUS
     brief: Wanhao Duplicator i3 Plus
+    since: 2.0.0
   - name: VORON
     brief: VORON Design
+    since: 2.0.0
   - name: TRONXY_V3_1_0
     brief: Tronxy TRONXY-V3-1.0
+    since: 2.0.0
   - name: Z_BOLT_X_SERIES
     brief: Z-Bolt X Series
+    since: 2.0.0
   - name: TT_OSCAR
     brief: TT OSCAR
+    since: 2.0.0
   - name: OVERLORD
     brief: Overlord/Overlord Pro
+    since: 2.0.0
   - name: HJC2560C_REV1
     brief: ADIMLab Gantry v1
+    since: 2.0.0
   - name: HJC2560C_REV2
     brief: ADIMLab Gantry v2
+    since: 2.0.0
   - name: TANGO
     brief: BIQU Tango V1
+    since: 2.0.0
   - name: MKS_GEN_L_V2
     brief: MKS GEN L V2
+    since: 2.0.0
   - name: MKS_GEN_L_V21
     brief: MKS GEN L V2.1
+    since: 2.0.7
   - name: COPYMASTER_3D
     brief: Copymaster 3D
+    since: 2.0.5.2
   - name: ORTUR_4
     brief: Ortur 4
+    since: 2.0.6
   - name: TENLOG_D3_HERO
     brief: Tenlog D3 Hero IDEX printer
+    since: 2.0.6
   - name: TENLOG_MB1_V23
     brief: Tenlog D3, D5, D6 IDEX Printer
+    since: 2.1.2
   - name: RAMPS_S_12_EEFB
     brief: "Ramps S 1.2 by Sakul.cz (Power outputs: Hotend0, Hotend1, Fan, Bed)"
+    since: 2.0.8
   - name: RAMPS_S_12_EEEB
     brief: "Ramps S 1.2 by Sakul.cz (Power outputs: Hotend0, Hotend1, Hotend2, Bed)"
+    since: 2.0.8
   - name: RAMPS_S_12_EFFB
     brief: "Ramps S 1.2 by Sakul.cz (Power outputs: Hotend, Fan0, Fan1, Bed)"
+    since: 2.0.8
   - name: LONGER3D_LK1_PRO
     brief: Longer LK1 PRO / Alfawise U20 Pro (PRO version)
+    since: 2.0.8
   - name: LONGER3D_LKx_PRO
     brief: Longer LKx PRO / Alfawise Uxx Pro (PRO version)
+    since: 2.0.8
   - name: ZRIB_V53
     brief: Zonestar zrib V5.3 (Chinese RAMPS replica)
+    since: 2.0.9.4
   - name: PXMALION_CORE_I3
     brief: Pxmalion Core I3
+    since: 2.0.9.4
   - name: PANOWIN_CUTLASS
     brief: Panowin Cutlass (as found in the Panowin F1)
     since: 2.1.3
@@ -212,18 +293,25 @@
   boards:
   - name: RAMBO
     brief: Rambo
+    since: 1.0.1
   - name: MINIRAMBO
     brief: Mini-Rambo
+    since: 1.1.0-RC2
   - name: MINIRAMBO_10A
     brief: Mini-Rambo 1.0a
+    since: 1.1.7
   - name: EINSY_RAMBO
     brief: Einsy Rambo
+    since: 1.1.9
   - name: EINSY_RETRO
     brief: Einsy Retro
+    since: 1.1.9
   - name: SCOOVO_X9H
     brief: abee Scoovo X9H
+    since: 1.1.0
   - name: RAMBO_THINKERV2
     brief: ThinkerV2
+    since: 2.0.8
 
 #
 # Other ATmega1280, ATmega2560
@@ -234,66 +322,97 @@
   boards:
   - name: CNCONTROLS_11
     brief: Cartesio CN Controls V11
+    since: 1.1.0-RC7
   - name: CNCONTROLS_12
     brief: Cartesio CN Controls V12
+    since: 1.1.0-RC7
   - name: CNCONTROLS_15
     brief: Cartesio CN Controls V15
+    since: 2.0.0
   - name: CHEAPTRONIC
     brief: Cheaptronic v1.0
+    since: 1.0.1
   - name: CHEAPTRONIC_V2
     brief: Cheaptronic v2.0
+    since: 1.1.0
   - name: MIGHTYBOARD_REVE
     brief: Makerbot Mightyboard Revision E
+    since: 1.1.0-RC8
   - name: MEGATRONICS
     brief: Megatronics
+    since: 1.0.1
   - name: MEGATRONICS_2
     brief: Megatronics v2.0
+    since: 1.0.1
   - name: MEGATRONICS_3
     brief: Megatronics v3.0
+    since: 1.1.0-RC2
   - name: MEGATRONICS_31
     brief: Megatronics v3.1
+    since: 1.1.0-RC8
   - name: MEGATRONICS_32
     brief: Megatronics v3.2
+    since: 2.0.0
   - name: ELEFU_3
     brief: Elefu Ra Board (v3)
+    since: 1.0.1
   - name: LEAPFROG
     brief: Leapfrog
+    since: 1.0.1
   - name: MEGACONTROLLER
     brief: Mega controller
+    since: 1.1.0-RC2
   - name: GT2560_REV_A
     brief: Geeetech GT2560 Rev A
+    since: 1.1.5
   - name: GT2560_REV_A_PLUS
     brief: Geeetech GT2560 Rev A+ (with auto level probe)
+    since: 1.1.5
   - name: GT2560_REV_B
     brief: Geeetech GT2560 Rev B
+    since: 2.0.8
   - name: GT2560_V3
     brief: Geeetech GT2560 Rev B for A10(M/T/D)
+    since: 2.0.0
   - name: GT2560_V4
     brief: Geeetech GT2560 Rev B for A10(M/T/D)
+    since: 2.0.8
   - name: GT2560_V3_MC2
     brief: Geeetech GT2560 Rev B for Mecreator2
+    since: 2.0.0
   - name: GT2560_V3_A20
     brief: Geeetech GT2560 Rev B for A20(M/T/D)
+    since: 2.0.0
   - name: EINSTART_S
     brief: Einstart retrofit
+    since: 2.0.0
   - name: WANHAO_ONEPLUS
     brief: Wanhao 0ne+ i3 Mini
+    since: 2.0.0
   - name: LEAPFROG_XEED2015
     brief: Leapfrog Xeed 2015
+    since: 2.0.2
   - name: PICA_REVB
     brief: PICA Shield (original version)
+    since: 2.0.4
   - name: PICA
     brief: PICA Shield (rev C or later)
+    since: 2.0.4
   - name: INTAMSYS40
     brief: Intamsys 4.0 (Funmat HT)
+    since: 2.0.5.3
   - name: MALYAN_M180
     brief: Malyan M180 Mainboard Version 2 (no display function, direct G-code only)
+    since: 2.0.8.2
   - name: GT2560_V4_A20
     brief: Geeetech GT2560 Rev B for A20(M/T/D)
+    since: 2.0.9.2
   - name: PROTONEER_CNC_SHIELD_V3
     brief: Mega controller & Protoneer CNC Shield V3.00
+    since: 2.0.9.2
   - name: WEEDO_62A
     brief: WEEDO 62A board (TINA2, Monoprice Cadet, etc.)
+    since: 2.0.9.4
   - name: GT2560_V41B
     brief: Geeetech GT2560 V4.1B for A10(M/T/D)
     since: 2.1.3
@@ -307,8 +426,10 @@
   boards:
   - name: MINITRONICS
     brief: Minitronics v1.0/1.1
+    since: 1.1.0-RC2
   - name: SILVER_GATE
     brief: Silvergate v1.0
+    since: 1.1.7
 
 #
 # Sanguinololu and Derivatives - ATmega644P, ATmega1284P
@@ -319,31 +440,43 @@
   boards:
   - name: SANGUINOLOLU_11
     brief: Sanguinololu < 1.2
+    since: 1.0.1
   - name: SANGUINOLOLU_12
     brief: Sanguinololu 1.2 and above
+    since: 1.0.1
   - name: MELZI
     brief: Melzi
+    since: 1.0.1
   - name: MELZI_V2
     brief: Melzi V2
+    since: 2.0.6
   - name: MELZI_MAKR3D
     brief: Melzi with ATmega1284 (MaKr3d version)
+    since: 1.1.0-RC2
   - name: MELZI_CREALITY
     brief: Melzi Creality3D (for CR-10 etc)
+    since: 1.1.5
   - name: MELZI_CREALITY_ENDER2
     brief: Melzi Creality3D (for Ender-2)
     since: 2.1.3
   - name: MELZI_MALYAN
     brief: Melzi Malyan M150
+    since: 1.1.9
   - name: MELZI_TRONXY
     brief: Tronxy X5S
+    since: 1.1.9
   - name: STB_11
     brief: STB V1.1
+    since: 1.0.1
   - name: AZTEEG_X1
     brief: Azteeg X1
+    since: 1.0.1
   - name: ANET_10
     brief: Anet 1.0 (Melzi clone)
+    since: 1.1.4
   - name: ZMIB_V2
     brief: ZoneStar ZMIB V2
+    since: 2.0.6.1
 
 #
 # Other ATmega644P, ATmega644, ATmega1284P
@@ -354,26 +487,37 @@
   boards:
   - name: GEN3_MONOLITHIC
     brief: Gen3 Monolithic Electronics
+    since: 1.0.1
   - name: GEN3_PLUS
     brief: Gen3+
+    since: 1.0.1
   - name: GEN6
     brief: Gen6
+    since: 1.0.1
   - name: GEN6_DELUXE
     brief: Gen6 deluxe
+    since: 1.0.1
   - name: GEN7_CUSTOM
     brief: Gen7 custom (Alfons3 Version) https://github.com/Alfons3/Generation_7_Electronics
+    since: 1.0.1
   - name: GEN7_12
     brief: Gen7 v1.1, v1.2
+    since: 1.0.1
   - name: GEN7_13
     brief: Gen7 v1.3
+    since: 1.0.1
   - name: GEN7_14
     brief: Gen7 v1.4
+    since: 1.0.1
   - name: OMCA_A
     brief: Alpha OMCA
+    since: 1.0.1
   - name: OMCA
     brief: Final OMCA
+    since: 1.0.1
   - name: SETHI
     brief: Sethi 3D_1
+    since: 1.0.1
 
 #
 # Teensyduino - AT90USB1286, AT90USB1286P
@@ -384,20 +528,28 @@
   boards:
   - name: TEENSYLU
     brief: Teensylu
+    since: 1.0.1
   - name: PRINTRBOARD
     brief: Printrboard (AT90USB1286)
+    since: 1.0.1
   - name: PRINTRBOARD_REVF
     brief: Printrboard Revision F (AT90USB1286)
+    since: 1.1.0-RC4
   - name: BRAINWAVE
     brief: Brainwave (AT90USB646)
+    since: 1.0.1
   - name: BRAINWAVE_PRO
     brief: Brainwave Pro (AT90USB1286)
+    since: 1.1.0-RC2
   - name: SAV_MKI
     brief: SAV Mk-I (AT90USB1286)
+    since: 1.0.1
   - name: TEENSY2
     brief: Teensy++2.0 (AT90USB1286)
+    since: 1.0.1
   - name: 5DPRINT
     brief: 5DPrint D8 Driver Board
+    since: 1.0.1
 
 #
 # LPC1768 ARM Cortex-M3
@@ -423,27 +575,37 @@
     since: 2.0.0
   - name: MKS_SBASE
     brief: MKS-Sbase
+    since: 2.0.0
   - name: AZSMZ_MINI
     brief: AZSMZ Mini
+    since: 2.0.0
   - name: BIQU_BQ111_A4
     brief: BIQU BQ111-A4
+    since: 2.0.0
   - name: SELENA_COMPACT
     brief: Selena Compact
+    since: 2.0.0
   - name: BIQU_B300_V1_0
     brief: BIQU B300_V1.0
+    since: 2.0.0
   - name: MKS_SGEN_L
     brief: MKS-SGen-L
+    since: 2.0.0
   - name: GMARSH_X6_REV1
     brief: GMARSH X6, revision 1 prototype
+    since: 2.0.0
   - name: BTT_SKR_V1_1
     brief: BigTreeTech SKR v1.1
+    since: 2.0.4
   - name: BTT_SKR_V1_3
     brief: BigTreeTech SKR v1.3
+    since: 2.0.4
   - name: BTT_SKR_V1_4
     brief: BigTreeTech SKR v1.4
+    since: 2.0.4
   - name: EMOTRONIC
     brief: eMotion-Tech eMotronic
-    since: 2.1.1
+    since: 2.0.9.5/2.1.1
 
 #
 # LPC1769 ARM Cortex-M3
@@ -454,30 +616,40 @@
   boards:
   - name: MKS_SGEN
     brief: MKS-SGen
+    since: 2.0.0
   - name: AZTEEG_X5_GT
     brief: Azteeg X5 GT
+    since: 2.0.0
   - name: AZTEEG_X5_MINI
     brief: Azteeg X5 Mini
+    since: 2.0.0
   - name: AZTEEG_X5_MINI_WIFI
     brief: Azteeg X5 Mini Wifi
+    since: 2.0.0
   - name: COHESION3D_REMIX
     brief: Cohesion3D ReMix
+    since: 2.0.0
   - name: COHESION3D_MINI
     brief: Cohesion3D Mini
+    since: 2.0.0
   - name: SMOOTHIEBOARD
     brief: Smoothieboard
+    since: 2.0.0
   - name: TH3D_EZBOARD
     brief: TH3D EZBoard v1.0
+    since: 2.0.0
   - name: BTT_SKR_V1_4_TURBO
     brief: BigTreeTech SKR v1.4 TURBO
-    since: 2.0.2
+    since: 2.0.4
   - name: MKS_SGEN_L_V2
     brief: MKS SGEN_L V2
+    since: 2.0.7
   - name: BTT_SKR_E3_TURBO
     brief: BigTreeTech SKR E3 Turbo
     since: 2.0.7
   - name: FLY_CDY
     brief: FLYmaker FLY CDY
+    since: 2.0.8
 
 #
 # SAM3X8E ARM Cortex-M3
@@ -488,60 +660,88 @@
   boards:
   - name: DUE3DOM
     brief: DUE3DOM for Arduino DUE
+    since: 2.0.0
   - name: DUE3DOM_MINI
     brief: DUE3DOM MINI for Arduino DUE
+    since: 2.0.0
   - name: RADDS
     brief: RADDS
+    since: 2.0.0
   - name: RAMPS_FD_V1
     brief: RAMPS-FD v1
+    since: 2.0.0
   - name: RAMPS_FD_V2
     brief: RAMPS-FD v2
+    since: 2.0.0
   - name: RAMPS_SMART_EFB
     brief: "RAMPS-SMART (Power outputs: Hotend, Fan, Bed)"
+    since: 2.0.0
   - name: RAMPS_SMART_EEB
     brief: "RAMPS-SMART (Power outputs: Hotend0, Hotend1, Bed)"
+    since: 2.0.0
   - name: RAMPS_SMART_EFF
     brief: "RAMPS-SMART (Power outputs: Hotend, Fan0, Fan1)"
+    since: 2.0.0
   - name: RAMPS_SMART_EEF
     brief: "RAMPS-SMART (Power outputs: Hotend0, Hotend1, Fan)"
+    since: 2.0.0
   - name: RAMPS_SMART_SF
     brief: "RAMPS-SMART (Power outputs: Spindle, Controller Fan)"
+    since: 2.0.0
   - name: RAMPS_DUO_EFB
     brief: "RAMPS Duo (Power outputs: Hotend, Fan, Bed)"
+    since: 2.0.0
   - name: RAMPS_DUO_EEB
     brief: "RAMPS Duo (Power outputs: Hotend0, Hotend1, Bed)"
+    since: 2.0.0
   - name: RAMPS_DUO_EFF
     brief: "RAMPS Duo (Power outputs: Hotend, Fan0, Fan1)"
+    since: 2.0.0
   - name: RAMPS_DUO_EEF
     brief: "RAMPS Duo (Power outputs: Hotend0, Hotend1, Fan)"
+    since: 2.0.0
   - name: RAMPS_DUO_SF
     brief: "RAMPS Duo (Power outputs: Spindle, Controller Fan)"
+    since: 2.0.0
   - name: RAMPS4DUE_EFB
     brief: "RAMPS4DUE (Power outputs: Hotend, Fan, Bed)"
+    since: 2.0.0
   - name: RAMPS4DUE_EEB
     brief: "RAMPS4DUE (Power outputs: Hotend0, Hotend1, Bed)"
+    since: 2.0.0
   - name: RAMPS4DUE_EFF
     brief: "RAMPS4DUE (Power outputs: Hotend, Fan0, Fan1)"
+    since: 2.0.0
   - name: RAMPS4DUE_EEF
     brief: "RAMPS4DUE (Power outputs: Hotend0, Hotend1, Fan)"
+    since: 2.0.0
   - name: RAMPS4DUE_SF
     brief: "RAMPS4DUE (Power outputs: Spindle, Controller Fan)"
+    since: 2.0.0
   - name: RURAMPS4D_11
     brief: RuRAMPS4Duo v1.1
+    since: 2.0.0
   - name: RURAMPS4D_13
     brief: RuRAMPS4Duo v1.3
+    since: 2.0.0
   - name: ULTRATRONICS_PRO
     brief: ReprapWorld Ultratronics Pro V1.0
+    since: 2.0.0
   - name: ARCHIM1
     brief: UltiMachine Archim1 (with DRV8825 drivers)
+    since: 2.0.0
   - name: ARCHIM2
     brief: UltiMachine Archim2 (with TMC2130 drivers)
+    since: 2.0.0
   - name: ALLIGATOR
     brief: Alligator Board R2
+    since: 2.0.0
   - name: CNCONTROLS_15D
     brief: Cartesio CN Controls V15 on DUE
+    since: 2.0.2
   - name: KRATOS32
     brief: K.3D Kratos32 (Arduino Due Shield)
+    since: 2.0.8
 
 #
 # SAM3X8C ARM Cortex-M3
@@ -552,8 +752,10 @@
   boards:
   - name: PRINTRBOARD_G2
     brief: Printrboard G2
+    since: 2.0.0
   - name: ADSK
     brief: Arduino DUE Shield Kit (ADSK)
+    since: 2.0.0
 
 #
 # STM32 ARM Cortex-M0+
@@ -564,16 +766,16 @@
   boards:
   - name: BTT_EBB42_V1_1
     brief: BigTreeTech EBB42 V1.1 (STM32G0B1CB)
-    since: 2.1.2.1
+    since: 2.1.2
   - name: BTT_SKR_MINI_E3_V3_0
     brief: BigTreeTech SKR Mini E3 V3.0 (STM32G0B0RE / STM32G0B1RE)
-    since: 2.1.2.1
+    since: 2.0.9.3
   - name: BTT_MANTA_E3_EZ_V1_0
     brief: BigTreeTech Manta E3 EZ V1.0 (STM32G0B1RE)
     since: 2.1.2.1
   - name: BTT_MANTA_M4P_V2_1
     brief: BigTreeTech Manta M4P V2.1 (STM32G0B0RE)
-    since: 2.1.2.1
+    since: 2.1.2.2
   - name: BTT_MANTA_M5P_V1_0
     brief: BigTreeTech Manta M5P V1.0 (STM32G0B1RE)
     since: 2.1.2.1
@@ -593,138 +795,205 @@
   boards:
   - name: MALYAN_M200_V2
     brief: STM32F070CB controller
+    since: 2.0.6
   - name: MALYAN_M300
     brief: STM32F070-based delta
+    since: 2.0.6
   - name: STM32F103RE
     brief: STM32F103RE Libmaple-based STM32F1 controller
+    since: 2.0.0
   - name: MALYAN_M200
     brief: STM32C8 Libmaple-based STM32F1 controller
+    since: 2.0.0
   - name: STM3R_MINI
     brief: STM32F103RE Libmaple-based STM32F1 controller
+    since: 2.0.0
   - name: GTM32_PRO_VB
     brief: STM32F103VE controller
+    since: 2.0.0
   - name: GTM32_MINI
     brief: STM32F103VE controller
+    since: 2.0.0
   - name: GTM32_MINI_A30
     brief: STM32F103VE controller
+    since: 2.0.0
   - name: GTM32_REV_B
     brief: STM32F103VE controller
+    since: 2.0.0
   - name: MORPHEUS
     brief: STM32F103C8 / STM32F103CB  Libmaple-based STM32F1 controller
+    since: 2.0.0
   - name: CHITU3D
     brief: Chitu3D (STM32F103RE)
+    since: 2.0.0
   - name: MKS_ROBIN
     brief: MKS Robin (STM32F103ZE)
+    since: 2.0.0
   - name: MKS_ROBIN_MINI
     brief: MKS Robin Mini (STM32F103VE)
+    since: 2.0.0
   - name: MKS_ROBIN_NANO
     brief: MKS Robin Nano (STM32F103VE)
+    since: 2.0.0
   - name: MKS_ROBIN_NANO_V2
     brief: MKS Robin Nano V2 (STM32F103VE)
+    since: 2.0.6
   - name: MKS_ROBIN_LITE
     brief: MKS Robin Lite/Lite2 (STM32F103RC)
+    since: 2.0.0
   - name: MKS_ROBIN_LITE3
     brief: MKS Robin Lite3 (STM32F103RC)
+    since: 2.0.1
   - name: MKS_ROBIN_PRO
     brief: MKS Robin Pro (STM32F103ZE)
+    since: 2.0.1
   - name: MKS_ROBIN_E3
     brief: MKS Robin E3 (STM32F103RC)
+    since: 2.0.6
   - name: MKS_ROBIN_E3_V1_1
     brief: MKS Robin E3 V1.1 (STM32F103RC)
+    since: 2.0.8
   - name: MKS_ROBIN_E3D
     brief: MKS Robin E3D (STM32F103RC)
+    since: 2.0.6
   - name: MKS_ROBIN_E3D_V1_1
     brief: MKS Robin E3D V1.1 (STM32F103RC)
+    since: 2.0.8
   - name: MKS_ROBIN_E3P
     brief: MKS Robin E3P (STM32F103VE)
+    since: 2.0.7
   - name: BTT_SKR_MINI_V1_1
     brief: BigTreeTech SKR Mini v1.1 (STM32F103RC)
+    since: 2.0.4
   - name: BTT_SKR_MINI_E3_V1_0
     brief: BigTreeTech SKR Mini E3 (STM32F103RC)
+    since: 2.0.0
   - name: BTT_SKR_MINI_E3_V1_2
     brief: BigTreeTech SKR Mini E3 V1.2 (STM32F103RC)
+    since: 2.0.0
   - name: BTT_SKR_MINI_E3_V2_0
     brief: BigTreeTech SKR Mini E3 V2.0 (STM32F103RC / STM32F103RE)
+    since: 2.0.6
   - name: BTT_SKR_MINI_MZ_V1_0
     brief: BigTreeTech SKR Mini MZ V1.0 (STM32F103RC)
+    since: 2.0.8
   - name: BTT_SKR_E3_DIP
     brief: BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
+    since: 2.0.4
   - name: BTT_SKR_CR6
     brief: BigTreeTech SKR CR6 v1.0 (STM32F103RE)
+    since: 2.0.8
   - name: JGAURORA_A5S_A1
     brief: JGAurora A5S A1 (STM32F103ZE)
+    since: 2.0.0
   - name: FYSETC_AIO_II
     brief: FYSETC AIO_II (STM32F103RC)
+    since: 2.0.0
   - name: FYSETC_CHEETAH
     brief: FYSETC Cheetah (STM32F103RC)
+    since: 2.0.0
   - name: FYSETC_CHEETAH_V12
     brief: FYSETC Cheetah V1.2 (STM32F103RC)
+    since: 2.0.0
   - name: LONGER3D_LK
     brief: Longer3D LK1/2 - Alfawise U20/U20+/U30 (STM32F103VE)
+    since: 2.0.0
   - name: CCROBOT_MEEB_3DP
     brief: ccrobot-online.com MEEB_3DP (STM32F103RC)
+    since: 2.0.6
   - name: CHITU3D_V5
     brief: Chitu3D TronXY X5SA V5 Board (STM32F103ZE)
+    since: 2.0.6
   - name: CHITU3D_V6
     brief: Chitu3D TronXY X5SA V6 Board (STM32F103ZE)
+    since: 2.0.6
   - name: CHITU3D_V9
     brief: Chitu3D TronXY X5SA V9 Board (STM32F103ZE)
+    since: 2.0.9.2
   - name: CREALITY_V4
     brief: Creality v4.x (STM32F103RC / STM32F103RE)
+    since: 2.0.6
   - name: CREALITY_V422
     brief: Creality v4.2.2 (STM32F103RC / STM32F103RE)
+    since: 2.0.9.4
   - name: CREALITY_V423
     brief: Creality v4.2.3 (STM32F103RC / STM32F103RE)
+    since: 2.0.9.3
   - name: CREALITY_V425
     brief: Creality v4.2.5 (STM32F103RC / STM32F103RE)
+    since: 2.0.9.5/2.1.1
   - name: CREALITY_V427
     brief: Creality v4.2.7 (STM32F103RC / STM32F103RE)
+    since: 2.0.6.1
   - name: CREALITY_V4210
     brief: Creality v4.2.10 (STM32F103RC / STM32F103RE) as found in the CR-30
+    since: 2.0.8
   - name: CREALITY_V431
     brief: Creality v4.3.1 (STM32F103RC / STM32F103RE)
+    since: 2.0.8
   - name: CREALITY_V431_A
     brief: Creality v4.3.1a (STM32F103RC / STM32F103RE)
+    since: 2.0.9.2
   - name: CREALITY_V431_B
     brief: Creality v4.3.1b (STM32F103RC / STM32F103RE)
+    since: 2.0.9.2
   - name: CREALITY_V431_C
     brief: Creality v4.3.1c (STM32F103RC / STM32F103RE)
+    since: 2.0.9.2
   - name: CREALITY_V431_D
     brief: Creality v4.3.1d (STM32F103RC / STM32F103RE)
+    since: 2.0.9.2
   - name: CREALITY_V452
     brief: Creality v4.5.2 (STM32F103RC / STM32F103RE)
+    since: 2.0.8
   - name: CREALITY_V453
     brief: Creality v4.5.3 (STM32F103RC / STM32F103RE)
+    since: 2.0.8
   - name: CREALITY_V521
     brief: Creality v5.2.1 (STM32F103VE) as found in the SV04
+    since: 2.1.2
   - name: CREALITY_V24S1
     brief: Creality v2.4.S1 (STM32F103RC / STM32F103RE) v101 as found in the Ender-7
+    since: 2.0.9.3
   - name: CREALITY_V24S1_301
     brief: Creality v2.4.S1_301 (STM32F103RC / STM32F103RE) v301 as found in the Ender-3 S1
+    since: 2.0.9.4
   - name: CREALITY_V25S1
     brief: Creality v2.5.S1 (STM32F103RE) as found in the CR-10 Smart Pro
+    since: 2.0.9.4
   - name: TRIGORILLA_PRO
     brief: Trigorilla Pro (STM32F103ZE)
+    since: 2.0.6
   - name: FLY_MINI
     brief: FLYmaker FLY MINI (STM32F103RC)
+    since: 2.0.7.1
   - name: FLSUN_HISPEED
     brief: FLSUN HiSpeedV1 (STM32F103VE)
+    since: 2.0.8
   - name: BEAST
     brief: STM32F103RE Libmaple-based controller
+    since: 2.0.0
   - name: MINGDA_MPX_ARM_MINI
     brief: STM32F103ZE Mingda MD-16
+    since: 2.0.8
   - name: GTM32_PRO_VD
     brief: STM32F103VE controller
+    since: 2.0.8
   - name: ZONESTAR_ZM3E2
     brief: Zonestar ZM3E2    (STM32F103RC)
+    since: 2.0.9.2
   - name: ZONESTAR_ZM3E4
     brief: Zonestar ZM3E4 V1 (STM32F103VC)
+    since: 2.0.9.2
   - name: ZONESTAR_ZM3E4V2
     brief: Zonestar ZM3E4 V2 (STM32F103VC)
+    since: 2.0.9.2
   - name: ERYONE_ERY32_MINI
     brief: Eryone Ery32 mini (STM32F103VE)
+    since: 2.0.9.3
   - name: PANDA_PI_V29
     brief: Panda Pi V2.9 - Standalone (STM32F103RC)
+    since: 2.0.9.4
   - name: SOVOL_V131
     brief: Sovol V1.3.1 (GD32F103RE)
     since: 2.1.2.1
@@ -753,8 +1022,10 @@
   boards:
   - name: TEENSY31_32
     brief: Teensy3.1 and Teensy3.2
+    since: 2.0.0
   - name: TEENSY35_36
     brief: Teensy3.5 and Teensy3.6
+    since: 2.0.0
 
 #
 # STM32 ARM Cortex-M4F
@@ -765,97 +1036,142 @@
   boards:
   - name: ARMED
     brief: Arm'ed STM32F4-based controller
+    since: 2.0.0
   - name: RUMBA32_V1_0
     brief: RUMBA32 STM32F446VE based controller from Aus3D
+    since: 2.0.6
   - name: RUMBA32_V1_1
     brief: RUMBA32 STM32F446VE based controller from Aus3D
+    since: 2.0.6
   - name: RUMBA32_MKS
     brief: RUMBA32 STM32F446VE based controller from Makerbase
+    since: 2.0.4
   - name: RUMBA32_BTT
     brief: RUMBA32 STM32F446VE based controller from BIGTREETECH
+    since: 2.0.9.2
   - name: BLACK_STM32F407VE
     brief: BLACK_STM32F407VE
+    since: 2.0.0
   - name: BLACK_STM32F407ZE
     brief: BLACK_STM32F407ZE
+    since: 2.0.0
   - name: BTT_SKR_MINI_E3_V3_0_1
     brief: BigTreeTech SKR Mini E3 V3.0.1 (STM32F401RC)
+    since: 2.1.2
   - name: BTT_SKR_PRO_V1_1
     brief: BigTreeTech SKR Pro v1.1 (STM32F407ZG)
+    since: 2.0.4
   - name: BTT_SKR_PRO_V1_2
     brief: BigTreeTech SKR Pro v1.2 (STM32F407ZG)
+    since: 2.0.6
   - name: BTT_BTT002_V1_0
     brief: BigTreeTech BTT002 v1.0 (STM32F407VG)
+    since: 2.0.4
   - name: BTT_E3_RRF
     brief: BigTreeTech E3 RRF (STM32F407VG)
+    since: 2.0.8
   - name: BTT_SKR_V2_0_REV_A
     brief: BigTreeTech SKR v2.0 Rev A (STM32F407VG)
+    since: 2.0.8.1
   - name: BTT_SKR_V2_0_REV_B
     brief: BigTreeTech SKR v2.0 Rev B (STM32F407VG/STM32F429VG)
+    since: 2.0.8.1
   - name: BTT_GTR_V1_0
     brief: BigTreeTech GTR v1.0 (STM32F407IGT)
+    since: 2.0.4
   - name: BTT_OCTOPUS_V1_0
     brief: BigTreeTech Octopus v1.0 (STM32F446ZE)
+    since: 2.0.8.1
   - name: BTT_OCTOPUS_V1_1
     brief: BigTreeTech Octopus v1.1 (STM32F446ZE)
+    since: 2.0.9
   - name: BTT_OCTOPUS_PRO_V1_0
     brief: BigTreeTech Octopus Pro v1.0 (STM32F446ZE / STM32F429ZG)
+    since: 2.0.9.3
   - name: LERDGE_K
     brief: Lerdge K (STM32F407ZG)
+    since: 2.0.0
   - name: LERDGE_S
     brief: Lerdge S (STM32F407VE)
+    since: 2.0.6
   - name: LERDGE_X
     brief: Lerdge X (STM32F407VE)
+    since: 2.0.0
   - name: FYSETC_S6
     brief: FYSETC S6 (STM32F446VE)
+    since: 2.0.0
   - name: FYSETC_S6_V2_0
     brief: FYSETC S6 v2.0 (STM32F446VE)
+    since: 2.0.6.1
   - name: FYSETC_SPIDER
     brief: FYSETC Spider (STM32F446VE)
+    since: 2.0.8
   - name: FLYF407ZG
     brief: FLYmaker FLYF407ZG (STM32F407ZG)
+    since: 2.0.1
   - name: MKS_ROBIN2
     brief: MKS Robin2 V1.0 (STM32F407ZE)
+    since: 2.0.1
   - name: MKS_ROBIN_PRO_V2
     brief: MKS Robin Pro V2 (STM32F407VE)
+    since: 2.0.8
   - name: MKS_ROBIN_NANO_V3
     brief: MKS Robin Nano V3 (STM32F407VG)
+    since: 2.0.8
   - name: MKS_ROBIN_NANO_V3_1
     brief: MKS Robin Nano V3.1 (STM32F407VE)
+    since: 2.0.9.4
   - name: MKS_MONSTER8_V1
     brief: MKS Monster8 V1 (STM32F407VE)
+    since: 2.0.9.5/2.1.1
   - name: MKS_MONSTER8_V2
     brief: MKS Monster8 V2 (STM32F407VE)
+    since: 2.0.9.5/2.1.1
   - name: ANET_ET4
     brief: ANET ET4 V1.x (STM32F407VG)
+    since: 2.0.8
   - name: ANET_ET4P
     brief: ANET ET4P V1.x (STM32F407VG)
+    since: 2.0.8
   - name: FYSETC_CHEETAH_V20
     brief: FYSETC Cheetah V2.0 (STM32F401RC)
+    since: 2.0.8
   - name: TH3D_EZBOARD_V2
     brief: TH3D EZBoard v2.0 (STM32F405RG)
+    since: 2.0.9.3
   - name: OPULO_LUMEN_REV3
     brief: Opulo Lumen PnP Controller REV3 (STM32F407VE / STM32F407VG)
+    since: 2.0.9.5/2.1.1
   - name: MKS_ROBIN_NANO_V1_3_F4
     brief: MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3 (STM32F407VE)
+    since: 2.0.9.2
   - name: MKS_EAGLE
     brief: MKS Eagle (STM32F407VE)
+    since: 2.0.9.3
   - name: ARTILLERY_RUBY
     brief: Artillery Ruby (STM32F401RC)
+    since: 2.0.9.3
   - name: FYSETC_SPIDER_V2_2
     brief: FYSETC Spider V2.2 (STM32F446VE)
+    since: 2.0.9.3
   - name: CREALITY_V24S1_301F4
     brief: Creality v2.4.S1_301F4 (STM32F401RC) as found in the Ender-3 S1 F4
+    since: 2.0.9.4
   - name: CREALITY_CR4NTXXC10
     brief: Creality E3 Free-runs Silent Motherboard (STM32F401RET6)
     since: 2.1.3
   - name: OPULO_LUMEN_REV4
     brief: Opulo Lumen PnP Controller REV4 (STM32F407VE / STM32F407VG)
+    since: 2.1.2
   - name: FYSETC_SPIDER_KING407
     brief: FYSETC Spider King407 (STM32F407ZG)
+    since: 2.1.2
   - name: MKS_SKIPR_V1
     brief: MKS SKIPR v1.0 all-in-one board (STM32F407VE)
+    since: 2.1.2
   - name: TRONXY_CXY_446_V10
     brief: TRONXY CXY-446-V10-220413/CXY-V6-191121 (STM32F446ZE)
+    since: 2.1.3
   - name: CREALITY_F401RE
     brief: Creality CR4NS200141C13 (STM32F401RE) as found in the Ender-5 S1
     since: 2.1.3
@@ -895,27 +1211,32 @@
   boards:
   - name: REMRAM_V1
     brief: RemRam v1
+    since: 2.0.0
   - name: TEENSY41
     brief: Teensy 4.1
+    since: 2.0.7
   - name: T41U5XBB
     brief: T41U5XBB Teensy 4.1 breakout board
+    since: 2.0.7
   - name: NUCLEO_F767ZI
     brief: ST NUCLEO-F767ZI Dev Board
+    since: 2.0.7.2
   - name: BTT_SKR_SE_BX_V2
     brief: BigTreeTech SKR SE BX V2.0 (STM32H743II)
+    since: 2.0.9.5/2.1.1
   - name: BTT_SKR_SE_BX_V3
     brief: BigTreeTech SKR SE BX V3.0 (STM32H743II)
+    since: 2.0.9.5/2.1.1
   - name: BTT_SKR_V3_0
     brief: BigTreeTech SKR V3.0 (STM32H743VI / STM32H723VG)
+    since: 2.0.9.4
   - name: BTT_SKR_V3_0_EZ
     brief: BigTreeTech SKR V3.0 EZ (STM32H743VI / STM32H723VG)
+    since: 2.0.9.4
   - name: BTT_OCTOPUS_MAX_EZ_V1_0
     brief: BigTreeTech Octopus Max EZ V1.0 (STM32H723ZE)
-    since: 2.1.2
+    since: 2.1.2.1
   - name: BTT_OCTOPUS_PRO_V1_0_1
-    brief: BigTreeTech Octopus Pro v1.0.1 (STM32H723ZE)
-    since: 2.1.3
-  - name: BOARD_BTT_OCTOPUS_PRO_V1_0_1
     brief: BigTreeTech Octopus Pro v1.0.1 (STM32H723ZE)
     since: 2.1.3
   - name: BTT_OCTOPUS_PRO_V1_1
@@ -937,24 +1258,34 @@
   boards:
   - name: ESPRESSIF_ESP32
     brief: Generic ESP32
+    since: 2.0.0
   - name: MRR_ESPA
     brief: MRR ESPA based on ESP32 (native pins only)
+    since: 2.0.1
   - name: MRR_ESPE
     brief: MRR ESPE based on ESP32 (with I2S stepper stream)
+    since: 2.0.1
   - name: E4D_BOX
     brief: E4d@BOX
+    since: 2.0.3
   - name: RESP32_CUSTOM
     brief: Rutilea ESP32 custom board
+    since: 2.0.9.3
   - name: FYSETC_E4
     brief: FYSETC E4
+    since: 2.0.8
   - name: PANDA_ZHU
     brief: Panda_ZHU
+    since: 2.0.9.3
   - name: PANDA_M4
     brief: Panda_M4
+    since: 2.0.9.3
   - name: MKS_TINYBEE
     brief: MKS TinyBee (with I2S stepper stream)
+    since: 2.0.9.3
   - name: ENWI_ESPNP
     brief: enwi ESPNP (with I2S stepper stream)
+    since: 2.0.9.4
   - name: GODI_CONTROLLER_V1_0
     brief: EDUTRONICS Godi Controller V1.0 based on ESP32
     since: 2.1.3
@@ -971,10 +1302,13 @@
   boards:
   - name: AGCM4_RAMPS_144
     brief: RAMPS 1.4.4
+    since: 2.0.4
   - name: BRICOLEMON_V1_0
     brief: Bricolemon
+    since: 2.0.9.4
   - name: BRICOLEMON_LITE_V1_0
     brief: Bricolemon Lite
+    since: 2.0.9.4
 
 #
 # SAMD21 ARM Cortex-M4
@@ -985,6 +1319,7 @@
   boards:
   - name: MINITRONICS20
     brief: Minitronics v2.0
+    since: 2.1.2
 
 #
 # HC32 ARM Cortex-M4
@@ -1022,4 +1357,4 @@
   boards:
   - name: SIMULATED
     brief: Simulated cartesian printer built with Dear ImGui, SDL, and OpenGL.
-    since: 2.1.2.2
+    since: 2.1.2.1

--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -116,7 +116,7 @@
     brief: MKS BASE 1.0 with Heroic HR4982 stepper drivers
     since: 1.1.9
   - name: MKS_GEN_13
-    brief: MKS GEN v1.3 or 1.4
+    brief: MKS GEN v1.3 or 1.4. Originally supported as `BOARD_MKS_13` since `1.1.0-RC6`.
     since: 1.1.9
   - name: MKS_GEN_L
     brief: MKS GEN L
@@ -200,7 +200,7 @@
     brief: Creality CR10S, CR20, and CR-X
     since: 2.0.0
   - name: DAGOMA_F5
-    brief: Dagoma F5
+    brief: Dagoma F5. Originally supported as `BOARD_RAMPS_DAGOMA` since `2.0.0`.
     since: 2.0.8
   - name: FYSETC_F6_13
     brief: FYSETC F6 1.3
@@ -595,13 +595,13 @@
     brief: GMARSH X6, revision 1 prototype
     since: 2.0.0
   - name: BTT_SKR_V1_1
-    brief: BigTreeTech SKR v1.1
+    brief: BigTreeTech SKR v1.1. Originally supported as `BOARD_BIGTREE_SKR_V1_1` since `2.0.0`.
     since: 2.0.4
   - name: BTT_SKR_V1_3
-    brief: BigTreeTech SKR v1.3
+    brief: BigTreeTech SKR v1.3. Originally supported as `BOARD_BIGTREE_SKR_V1_3` since `2.0.0`.
     since: 2.0.4
   - name: BTT_SKR_V1_4
-    brief: BigTreeTech SKR v1.4
+    brief: BigTreeTech SKR v1.4. Originally supported as `BOARD_BIGTREE_SKR_V1_4` since `2.0.1`.
     since: 2.0.4
   - name: EMOTRONIC
     brief: eMotion-Tech eMotronic
@@ -639,7 +639,7 @@
     brief: TH3D EZBoard v1.0
     since: 2.0.0
   - name: BTT_SKR_V1_4_TURBO
-    brief: BigTreeTech SKR v1.4 TURBO
+    brief: BigTreeTech SKR v1.4 TURBO. Originally supported as `BOARD_BIGTREE_SKR_V1_4_TURBO` since `2.0.2`.
     since: 2.0.4
   - name: MKS_SGEN_L_V2
     brief: MKS SGEN_L V2
@@ -774,7 +774,7 @@
     brief: BigTreeTech Manta E3 EZ V1.0 (STM32G0B1RE)
     since: 2.1.2.1
   - name: BTT_MANTA_M4P_V2_1
-    brief: BigTreeTech Manta M4P V2.1 (STM32G0B0RE)
+    brief: BigTreeTech Manta M4P V2.1 (STM32G0B0RE). Originally supported as `BOARD_BTT_MANTA_M4P_V1_0` since `2.1.2.1`.
     since: 2.1.2.2
   - name: BTT_MANTA_M5P_V1_0
     brief: BigTreeTech Manta M5P V1.0 (STM32G0B1RE)
@@ -863,7 +863,7 @@
     brief: MKS Robin E3P (STM32F103VE)
     since: 2.0.7
   - name: BTT_SKR_MINI_V1_1
-    brief: BigTreeTech SKR Mini v1.1 (STM32F103RC)
+    brief: BigTreeTech SKR Mini v1.1 (STM32F103RC). Originally supported as `BOARD_BIGTREE_SKR_MINI_V1_1` since `2.0.0`.
     since: 2.0.4
   - name: BTT_SKR_MINI_E3_V1_0
     brief: BigTreeTech SKR Mini E3 (STM32F103RC)
@@ -878,7 +878,7 @@
     brief: BigTreeTech SKR Mini MZ V1.0 (STM32F103RC)
     since: 2.0.8
   - name: BTT_SKR_E3_DIP
-    brief: BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
+    brief: BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE). Originally supported as `BOARD_BIGTREE_SKR_E3_DIP` since `2.0.0`.
     since: 2.0.4
   - name: BTT_SKR_CR6
     brief: BigTreeTech SKR CR6 v1.0 (STM32F103RE)
@@ -1038,13 +1038,13 @@
     brief: Arm'ed STM32F4-based controller
     since: 2.0.0
   - name: RUMBA32_V1_0
-    brief: RUMBA32 STM32F446VE based controller from Aus3D
+    brief: RUMBA32 STM32F446VE based controller from Aus3D. Originally supported as `BOARD_RUMBA32` since `2.0.0`.
     since: 2.0.6
   - name: RUMBA32_V1_1
     brief: RUMBA32 STM32F446VE based controller from Aus3D
     since: 2.0.6
   - name: RUMBA32_MKS
-    brief: RUMBA32 STM32F446VE based controller from Makerbase
+    brief: RUMBA32 STM32F446VE based controller from Makerbase. Originally supported as `BOARD_RUMBA32` since `2.0.0`.
     since: 2.0.4
   - name: RUMBA32_BTT
     brief: RUMBA32 STM32F446VE based controller from BIGTREETECH
@@ -1059,22 +1059,22 @@
     brief: BigTreeTech SKR Mini E3 V3.0.1 (STM32F401RC)
     since: 2.1.2
   - name: BTT_SKR_PRO_V1_1
-    brief: BigTreeTech SKR Pro v1.1 (STM32F407ZG)
+    brief: BigTreeTech SKR Pro v1.1 (STM32F407ZG). Originally supported as `BOARD_BIGTREE_SKR_PRO_V1_1` since `2.0.0`.
     since: 2.0.4
   - name: BTT_SKR_PRO_V1_2
     brief: BigTreeTech SKR Pro v1.2 (STM32F407ZG)
     since: 2.0.6
   - name: BTT_BTT002_V1_0
-    brief: BigTreeTech BTT002 v1.0 (STM32F407VG)
+    brief: BigTreeTech BTT002 v1.0 (STM32F407VG). Originally supported as `BOARD_BIGTREE_BTT002_V1_0` since `2.0.0`.
     since: 2.0.4
   - name: BTT_E3_RRF
     brief: BigTreeTech E3 RRF (STM32F407VG)
     since: 2.0.8
   - name: BTT_SKR_V2_0_REV_A
-    brief: BigTreeTech SKR v2.0 Rev A (STM32F407VG)
+    brief: BigTreeTech SKR v2.0 Rev A (STM32F407VG). Originally supported as `BOARD_BTT_SKR_V2_0` since `2.0.8`.
     since: 2.0.8.1
   - name: BTT_SKR_V2_0_REV_B
-    brief: BigTreeTech SKR v2.0 Rev B (STM32F407VG/STM32F429VG)
+    brief: BigTreeTech SKR v2.0 Rev B (STM32F407VG/STM32F429VG). Originally supported as `BOARD_BTT_SKR_V2_0` since `2.0.8`.
     since: 2.0.8.1
   - name: BTT_GTR_V1_0
     brief: BigTreeTech GTR v1.0 (STM32F407IGT)
@@ -1122,10 +1122,10 @@
     brief: MKS Robin Nano V3.1 (STM32F407VE)
     since: 2.0.9.4
   - name: MKS_MONSTER8_V1
-    brief: MKS Monster8 V1 (STM32F407VE)
+    brief: MKS Monster8 V1 (STM32F407VE). Originally supported as `BOARD_MKS_MONSTER8` since `2.0.9.2`.
     since: 2.0.9.5/2.1.1
   - name: MKS_MONSTER8_V2
-    brief: MKS Monster8 V2 (STM32F407VE)
+    brief: MKS Monster8 V2 (STM32F407VE). Originally supported as `BOARD_MKS_MONSTER8` since `2.0.9.2`.
     since: 2.0.9.5/2.1.1
   - name: ANET_ET4
     brief: ANET ET4 V1.x (STM32F407VG)
@@ -1137,7 +1137,7 @@
     brief: FYSETC Cheetah V2.0 (STM32F401RC)
     since: 2.0.8
   - name: TH3D_EZBOARD_V2
-    brief: TH3D EZBoard v2.0 (STM32F405RG)
+    brief: TH3D EZBoard v2.0 (STM32F405RG). Originally supported as `BOARD_TH3D_EZBOARD_LITE_V2` since `2.0.9.2`.
     since: 2.0.9.3
   - name: OPULO_LUMEN_REV3
     brief: Opulo Lumen PnP Controller REV3 (STM32F407VE / STM32F407VG)
@@ -1170,7 +1170,7 @@
     brief: MKS SKIPR v1.0 all-in-one board (STM32F407VE)
     since: 2.1.2
   - name: TRONXY_CXY_446_V10
-    brief: TRONXY CXY-446-V10-220413/CXY-V6-191121 (STM32F446ZE)
+    brief: TRONXY CXY-446-V10-220413/CXY-V6-191121 (STM32F446ZE). Originally supported as `BOARD_TRONXY_V10` since `2.1.2`.
     since: 2.1.3
   - name: CREALITY_F401RE
     brief: Creality CR4NS200141C13 (STM32F401RE) as found in the Ender-5 S1
@@ -1222,10 +1222,10 @@
     brief: ST NUCLEO-F767ZI Dev Board
     since: 2.0.7.2
   - name: BTT_SKR_SE_BX_V2
-    brief: BigTreeTech SKR SE BX V2.0 (STM32H743II)
+    brief: BigTreeTech SKR SE BX V2.0 (STM32H743II). Originally supported as `BOARD_BTT_SKR_SE_BX` since `2.0.8`.
     since: 2.0.9.5/2.1.1
   - name: BTT_SKR_SE_BX_V3
-    brief: BigTreeTech SKR SE BX V3.0 (STM32H743II)
+    brief: BigTreeTech SKR SE BX V3.0 (STM32H743II). Originally supported as `BOARD_BTT_SKR_SE_BX` since `2.0.8`.
     since: 2.0.9.5/2.1.1
   - name: BTT_SKR_V3_0
     brief: BigTreeTech SKR V3.0 (STM32H743VI / STM32H723VG)
@@ -1356,5 +1356,5 @@
     It can simulate a Character-based LCD, standard Graphical LCD, or a TFT Color display.
   boards:
   - name: SIMULATED
-    brief: Simulated cartesian printer built with Dear ImGui, SDL, and OpenGL.
+    brief: Simulated cartesian printer built with Dear ImGui, SDL, and OpenGL. Originally supported as `BOARD_LINUX_RAMPS` since `2.0.0`.
     since: 2.1.2.1

--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -876,6 +876,17 @@
     since: 2.1.3
 
 #
+# Other ARM Cortex-M4
+#
+
+- group: Other ARM Cortex-M4
+  long:
+  boards:
+  - name: CREALITY_CR4NS
+    brief: Creality CR4NS200320C13 (GD32F303RET6) as found in the Ender-3 V3 SE
+    since: 2.1.3
+
+#
 # ARM Cortex-M7
 #
 

--- a/_hardware/boards.md
+++ b/_hardware/boards.md
@@ -4,7 +4,7 @@ description:  'Complete list of hardware supported by Marlin'
 tag: info
 
 author: jbrazio
-contrib: thinkyhead
+contrib: thinkyhead, thisiskeithb
 category: hardware
 
 ---

--- a/_includes/boards.md
+++ b/_includes/boards.md
@@ -61,7 +61,7 @@ If you're developing a custom board, try to use common pinouts as much as possib
 <table class="table table-condensed table-striped">
 <tr><th>Name</th><th>Description</th><th>Version</th></tr>
 {% for board in item.boards %}
-<tr{% if board.class %} class="{{ board.class }}"{% endif %}><td>BOARD_{{ board.name }}</td><td>{{ board.brief }}</td><td>{% if board.since %}{{ board.since }}{% endif %}</td></tr>
+<tr{% if board.class %} class="{{ board.class }}"{% endif %}><td>BOARD_{{ board.name }}{% if board.old[0].name %}<br/><em>(BOARD_{{ board.old[0].name }})</em>{% endif %}</td><td>{{ board.brief }}</td><td>{% if board.since %}{{ board.since }}{% endif %}{% if board.old[0].since %}<br/><em>({{ board.old[0].since }})</em>{% endif %}</td></tr>
 {% endfor %}
 </table>
 {% endfor %}


### PR DESCRIPTION
### Description

- `TRONXY_V10` => `TRONXY_CXY_446_V10`
- Add Dagoma D6 (`DAGOMA_D6`)
- Add Creality CR4NS200320C13 (`CREALITY_CR4NS`)
- Update Marlin Simulator description to include 2004/character-based LCD support
- Fix & add missing "supported since" version info for all boards