### PR TITLE
remove duplicate entry boards.yml

### DIFF
--- a/_data/boards.yml
+++ b/_data/boards.yml
@@ -1272,17 +1272,6 @@
     since: 2.1.3
 
 #
-# Other ARM Cortex-M4
-#
-
-- group: Other ARM Cortex-M4
-  long:
-  boards:
-  - name: CREALITY_CR4NS
-    brief: Creality CR4NS200320C13 (GD32F303RET6) as found in the Ender-3 V3 SE
-    since: 2.1.3
-
-#
 # ARM Cortex-M7
 #
 


### PR DESCRIPTION
There are two entries of the following, I removed one

```
#
# Other ARM Cortex-M4
#

- group: Other ARM Cortex-M4
  long:
  boards:
  - name: CREALITY_CR4NS
    brief: Creality CR4NS200320C13 (GD32F303RET6) as found in the Ender-3 V3 SE
    since: 2.1.3

```