### PR TITLE
🩹 Fix responsive behavior on narrow screens

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -105,7 +105,7 @@
       <div class="container {% if page.url == '/' or page.collection == 'tools' or page.collection == 'meta' %} noshift-footer {% else %} shift-footer {% endif %}">
         <div class="row">
           <div class="col-8">
-            <p>Brought to you with <i class="fa fa-heart text-danger" aria-hidden="true"></i> lack of
+            <p class="text-center">Brought to you with <i class="fa fa-heart text-danger" aria-hidden="true"></i> lack of
               <i class="fa fa-bed" aria-hidden="true"></i> and lots of
               <i class="fa fa-coffee" aria-hidden="true"></i>. <br />
               The contents of this website are &copy; {{ site.time | date: '%Y' }} under the terms of the <a href="//www.gnu.org/licenses/gpl-3.0.txt">GPLv3</a> License.</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -105,8 +105,8 @@
       <div class="container {% if page.url == '/' or page.collection == 'tools' or page.collection == 'meta' %} noshift-footer {% else %} shift-footer {% endif %}">
         <div class="row">
           <div class="col-8">
-            <p class="text-center">Brought to you with <i class="fa fa-heart text-danger" aria-hidden="true"></i> lack of
-              <i class="fa fa-bed" aria-hidden="true"></i> and lots of
+            <p class="text-center">Brought to you with <i class="fa fa-heart text-danger" aria-hidden="true"></i>, lack of
+              <i class="fa fa-bed" aria-hidden="true"></i>, and lots of
               <i class="fa fa-coffee" aria-hidden="true"></i>. <br />
               The contents of this website are &copy; {{ site.time | date: '%Y' }} under the terms of the <a href="//www.gnu.org/licenses/gpl-3.0.txt">GPLv3</a> License.</p>
           </div>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1202,7 +1202,7 @@ summary h3 { display: inline; }
 footer>.container { display: block; clear: both; width: 100%}
 .noshift-footer, .shift-footer {
   padding: 1em;
-  .back-to-top { margin-top: -3pc; }
+  .back-to-top { margin-top: -0.5pc; }
 }
 @media (min-width: 991px) {
   .shift-footer { padding-left: 369px !important; }

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1270,8 +1270,7 @@ footer>.container { display: block; clear: both; width: 100%}
 @media (max-width: $screen-sm-min) {
   li#searchbox input[type="search"] { width: 10em; }
   .tocify.bigtoc, .custom-fixed-sidebar .tocify { width: 324px; }
-  //footer>.container { width: 100%; padding-left: 0; }
-  footer>.container { width: ($screen-lg-min - 30px - 20px); padding-left: 312px; }
+  footer>.container { width: 100%; padding-left: 0; }
 }
 // Fix headings in panels
 div.panel.panel-info, div.panel.panel-warning {


### PR DESCRIPTION
### Description

Re-fix unintended side scrolling on narrow screens (like my phone). This basically reapplies the fix from #400.

Once unintended side scrolling was fixed, the "Back to top" text overlapped the footer on the narrowest of screens, so that was fixed as well:

| Before  | After  |
|:-:|:-:|
| ![image](https://github.com/user-attachments/assets/4a911239-3591-488b-9635-5c2e4096c90b) | ![image](https://github.com/user-attachments/assets/822ee586-5ddd-4f66-ac08-b103e5a42ce7) |

 I also added the `text-center` class to center the footer text & tweaked punctuation to add missing commas.

### Related Issues

- #400