### PR TITLE
📝 Overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ This repository contains the raw documentation for [Marlin 3D printer firmware](
 
 - [Technical details](#technical-details)
 - [How to contribute](#how-to-contribute)
-  * [Coding style](#coding-style)
-  * [Editorial style](#editorial-style)
-  * [Work in progress](#work-in-progress)
+  - [Coding style](#coding-style)
+  - [Editorial style](#editorial-style)
+  - [Work in progress](#work-in-progress)
 - [Local Jekyll preview](#local-jekyll-preview)
-  * [Installing buildroot on Windows](#installing-buildroot-on-windows)
-  * [Installing buildroot on macOS](#installing-buildroot-on-macos)
-  * [Installing buildroot on Ubuntu](#installing-buildroot-on-ubuntu)
-- [Jekyll primer](#jekyll-primer)
-- [Previewing content](#previewing-content)
-- [License](#license)
+  - [Installing Ruby on Windows](#installing-ruby-on-windows)
+  - [Installing Ruby on macOS](#installing-ruby-on-macos)
+  - [Installing Ruby on Ubuntu](#installing-ruby-on-ubuntu)
+  - [Installing Jekyll](#installing-jekyll)
+  - [Jekyll basics](#jekyll-basics)
+  - [Previewing content](#previewing-content)
+  - [License](#license)
 
 ## Technical details
 
@@ -96,7 +97,7 @@ You can use the `_tmp` folder for work-in-progress, and they will not be include
 
 If you'd like to be able to preview your contributions before submitting them, you'll need to install Jekyll on your system. Instructions for Windows and macOS are given below:
 
-### Installing buildroot on Windows
+### Installing Ruby on Windows
 
 1. Download and install a Ruby+Devkit `3.3.4` from [RubyInstaller Download Archives](//rubyinstaller.org/downloads/archives/). Use default options for installation.
 
@@ -110,9 +111,9 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```sh
    ruby -v
    ```
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Jekyll primer](#jekyll-primer) section below.
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Installing Jekyll](#installing-jekyll) section below.
 
-### Installing buildroot on macOS
+### Installing Ruby on macOS
 
 > [!NOTE]
 > Ruby may come preinstalled, but macOS' "system Ruby" is outdated, unmaintained, and not recommended for general use.
@@ -135,9 +136,9 @@ If you'd like to be able to preview your contributions before submitting them, y
 
    - Homebrew:
 
-      ```sh
-      brew install chruby ruby-install xz
-      ```
+     ```sh
+     brew install chruby ruby-install xz
+     ```
 
    - MacPorts:
 
@@ -151,13 +152,15 @@ If you'd like to be able to preview your contributions before submitting them, y
    ruby-install ruby 3.3.4
    ```
 
-   This will take a few minutes.
+   This will take a few minutes. (It's not as quick as the `rbenv` install you may have used previously.)
 
 4. Configure your shell to automatically use `chruby`:
 
    - Homebrew:
 
      ```sh
+     echo "" >> ~/.zshrc
+     echo "# Ruby Configuration" >> ~/.zshrc
      echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
      echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
      echo "chruby ruby-3.3.4" >> ~/.zshrc
@@ -166,6 +169,8 @@ If you'd like to be able to preview your contributions before submitting them, y
    - MacPorts:
 
      ```sh
+     echo "" >> ~/.zshrc
+     echo "# Ruby Configuration" >> ~/.zshrc
      echo "source ${prefix}/opt/local/share/chruby/chruby.sh" >> ~/.zshrc
      echo "source ${prefix}/opt/local/share/chruby/auto.sh" >> ~/.zshrc
      echo "chruby ruby-3.3.4" >> ~/.zshrc
@@ -177,15 +182,18 @@ If you'd like to be able to preview your contributions before submitting them, y
    ruby -v
    ```
 
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, proceed to the [Jekyll primer](#jekyll-primer) section below.
+   It should report `ruby 3.3.4 (2024-07-09 revision be1089c8ec)`. If not, repeat the above steps.
 
-### Installing buildroot on Ubuntu
+6. Proceed to the [Installing Jekyll](#installing-jekyll) section below. (Note that `bundler` is already included.)
+
+### Installing Ruby on Ubuntu
 
 1. Ensure APT is up to date:
 
    ```sh
    sudo apt update
    ```
+
 2. Install prerequisites:
 
    ```sh
@@ -230,30 +238,33 @@ If you'd like to be able to preview your contributions before submitting them, y
    gem install bundler
    ```
 
-7. Proceed to the [Jekyll primer](#jekyll-primer) section below.
+7. Proceed to Installing Jekyll….
 
-## Jekyll primer
+### Installing Jekyll
 
-Under Jekyll, we use YAML, Markdown, Liquid, and HTML to fill out the site content and layout. A `_config.yml` file defines the site structure using "collections" that correspond to site sub-folders. The site is "compiled" to produce a static HTML and Javascript file structure. The most important folders are:
-
-- `_layouts` contains the general layouts (aka page templates).
-- `_includes` has partial layouts included by others.
-- `_meta` is where we keep top-level page descriptions.
-- Site sub-pages: `_basics`, `_configuration`, `_development`, `_features`, `_gcode`, `_hardware`.
-
-## Previewing content
-
-Now that Ruby is installed, you'll be able to use Jekyll to preview your changes exactly as they will appear on the final site. Just open a new Command Prompt or Terminal window, `cd` to change the working path to **your MarlinDocumentation fork**, and execute the following commands:
+Once Ruby is installed you'll need to install Jekyll itself. Open the Command Prompt or Terminal and `cd` to the working path of **your MarlinDocumentation fork**. Execute the following commands:
 
 ```sh
+rm -f Gemfile.lock
 bundle config set path 'vendor/bundle'
 bundle install
 ```
 
 > [!NOTE]
-> You'll only need to execute the above commands **once** to install all the required Ruby gems, including Jekyll itself. If you get errors at this stage, you may need to update your Ruby installation, fix your Ruby environment, or resolve dependencies between the Ruby gems.
+> You only need to execute the above commands **once** to complete the install. If you see errors at this stage you may need to update your Ruby installation, fix your Ruby environment, or resolve dependencies between the Ruby gems.
 
-To start a web server & preview your changes, run the following command:
+### Jekyll basics
+
+Jekyll uses a combination of YAML, Markdown, Liquid, and HTML to define the site content and layout. A `_config.yml` file defines a site structure with "collections" corresponding to sub-folders. The website is "compiled" to produce static HTML and Javascript. The most important folders in the site are:
+
+- `_layouts` contains the general layouts (aka page templates).
+- `_includes` has partial layouts included by others.
+- `_meta` is where we keep top-level page descriptions.
+- Sections: `_basics`, `_configuration`, `_development`, `_features`, `_gcode`, `_hardware`….
+
+### Previewing content
+
+To start a mini web server and preview your changes, run the following command:
 
 ```sh
 bundle exec jekyll serve --watch --incremental

--- a/README.md
+++ b/README.md
@@ -1,43 +1,89 @@
-# Marlin Documentation Project
+<p align="center"><img src="https://raw.githubusercontent.com/MarlinFirmware/Marlin/bugfix-2.1.x/buildroot/share/pixmaps/logo/marlin-outrun-nf-500.png" height="250" alt="MarlinFirmware's logo" /></p>
 
-This repository contains the raw documentation for [Marlin 3D printer firmware](//github.com/MarlinFirmware/Marlin) which is regularly deployed to [marlinfw.org](//marlinfw.org/). This documentation is open and available on Github so anyone may contribute by completing, correcting, or creating articles.
+<h1 align="center">Marlin Documentation Project</h1>
 
-<div align="center"><img width="300" src="https://raw.githubusercontent.com/MarlinFirmware/Marlin/bugfix-2.1.x/buildroot/share/pixmaps/logo/marlin-outrun-nf-500.png" /></div>
+<p align="center">
+    <a href="/LICENSE"><img alt="GPL-V3.0 License" src="https://img.shields.io/github/license/MarlinFirmware/MarlinDocumentation.svg"></a>
+    <a href="//github.com/MarlinFirmware/MarlinDocumentation/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/marlinfirmware/marlindocumentation.svg"></a>
+    <a href="//github.com/MarlinFirmware/MarlinDocumentation/releases"><img alt="Last Updated" src="https://img.shields.io/github/last-commit/marlinfirmware/marlindocumentation?label=last%20updated"></a>
+    <a href="//github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml"><img alt="Jekyll Deploy Status" src="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml/badge.svg"></a>
+    <a href="//github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
+    <br />
+    <a href="//fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
+</p>
+
+## About
+
+This repository contains the raw documentation for [Marlin 3D printer firmware](//github.com/MarlinFirmware/Marlin) which is automatically deployed to [marlinfw.org](//marlinfw.org/). This documentation is open and available on GitHub so anyone may contribute by completing, correcting, or creating articles.
+
+## Table of Contents
+
+- [Technical details](#technical-details)
+- [How to contribute](#how-to-contribute)
+  * [Coding style](#coding-style)
+  * [Editorial style](#editorial-style)
+  * [Work in progress](#work-in-progress)
+- [Local Jekyll preview](#local-jekyll-preview)
+  * [Installing buildroot on Windows](#installing-buildroot-on-windows)
+  * [Installing buildroot on macOS](#installing-buildroot-on-macos)
+  * [Installing buildroot on Ubuntu](#installing-buildroot-on-ubuntu)
+- [Jekyll primer](#jekyll-primer)
+- [Previewing content](#previewing-content)
+- [License](#license)
 
 ## Technical details
 
 The Marlin Documentation Project is built using the following technologies:
-- [Ruby](//www.ruby-lang.org/en/downloads/)
-- [RubyGems](//rubygems.org/pages/download)
+
+- [Ruby](//www.ruby-lang.org/)
+- [RubyGems](//rubygems.org/)
 - [Jekyll](//jekyllrb.com/)
-- [Github pages](//pages.github.com/)
+- [GitHub Pages](//pages.github.com/)
 
 ## How to contribute
 
-To work with the documentation, first make a Fork of this repository in your own Github account, then locally clone **your MarlinDocumentation fork**. You should do all work within your own fork before submitting it as a Pull Request to the `master` branch. You can download the [GitHub Desktop app](//desktop.github.com/) and use Github's "Open in Desktop" option, or from your own desktop open a terminal/cmd window and do:
-  - `cd C:\` (for example)
-  - `git clone https://github.com/MarlinFirmware/MarlinDocumentation.git`
+To work with the documentation, first [fork](//docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) this repository to your GitHub account, then clone **your MarlinDocumentation fork** locally. You should do all work within your own fork before submitting it as a [Pull Request](//docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) to the `master` branch. You can download the [GitHub Desktop app](//github.com/apps/desktop) and use GitHub's "Open in Desktop" option, or from your own desktop, open a terminal/cmd window and do:
+
+For example, change into the root of C:\\:
+
+```bash
+cd C:\
+```
+
+Clone Marlin Documentation repository:
+
+```bash
+git clone https://github.com/MarlinFirmware/MarlinDocumentation.git
+```
 
 This will create a local `C:\MarlinDocumentation` folder linked to your fork.
 
-To add new documentation or edit existing documentation, start by creating a new branch as a copy of the 'master' branch. You can do this using the Github web interface, from within Github Desktop, or from the command line.
+To add new documentation or edit existing documentation, start by [creating a new branch](//docs.github.com/en/issues/tracking-your-work-with-issues/creating-a-branch-for-an-issue) as a copy of the `master` branch. You can do this using the GitHub web interface, from within GitHub Desktop, or from the command line.
 
 If your new document is about "mashed potatoes" then name the new branch accordingly:
+
 ```
 git checkout master -b doc-mashed_potatoes
 ```
-Inside the `_docs` folder add the new file `mashed-potatoes.md` and let flow all your creativity into it. When you feel your masterpiece is ready to be shared with the world, commit the changes and push them up to your fork of **MarlinDocumentation**, then start a new Pull Request to the upstream repository (MarlinFirmware/MarlinDocumentation). This is done most easily from within the Github Desktop app. Please read Github's documentation on managing branches and creating Pull Requests if you're not sure how to proceed.
-```
+
+Inside the `_docs` folder, add the new file `mashed-potatoes.md` and let flow all your creativity into it. When you feel your masterpiece is ready to be shared with the world, commit the changes and push them up to **your MarlinDocumentation fork**. This is done most easily from within the GitHub Desktop app, but here are the command line commands for reference:
+
+```shell
 git add mashed-potatoes.md
 git commit -m "Added a new document about potatoes"
 git push
 ```
 
-## Coding style
+Next, start a new Pull Request to the upstream repository ([MarlinFirmware/MarlinDocumentation](//github.com/MarlinFirmware/MarlinDocumentation)).
 
-This Jekyll-based site is based on the Markdown language in delicious YAML wrapper. Be careful with this format because even small typos can cause Jekyll to reject the page. If you've installed Jekyll as described below, you can use it to build and preview the documentation and this will tell you where your errors are.
+> [!TIP]
+> Check out GitHub's documentation on [creating a new branch](//docs.github.com/en/issues/tracking-your-work-with-issues/creating-a-branch-for-an-issue), [managing branches](//docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository), and creating [Pull Requests](//docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) if you're new to contributing with git.
 
-## Editorial style
+### Coding style
+
+This Jekyll-based site is based on the [Markdown](//www.markdownguide.org/) language in delicious [YAML](//yaml.org/) wrapper. Be careful with this format because even small typos can cause Jekyll to reject the page. If you've installed Jekyll as described below, you can use it to build and preview the documentation and this will tell you where your errors are.
+
+### Editorial style
 
 Try to be neutral, concise, and straightforward. Avoid use of personal pronouns, unless avoiding them proves awkward. Provide images and give examples where needed. Check your spelling, grammar, and punctuation.
 
@@ -45,70 +91,150 @@ Try to be neutral, concise, and straightforward. Avoid use of personal pronouns,
 
 You can use the `_tmp` folder for work-in-progress, and they will not be included in the site deployment.
 
-## Local Jekyll Preview
+## Local Jekyll preview
 
-If you'd like to be able to preview your contributions before submitting them, you'll need to install Jekyll on your system. Instructions are given below. As this is a non-trivial process, we recommend reading one of the following tutorials for a quick start with Jekyll:
-- [Jekyll running on Windows](//jekyll-windows.juthilo.com/)
-- [Jekyll running on Linux, Unix, or Mac OS X](//jekyllrb.com/docs/installation/)
+If you'd like to be able to preview your contributions before submitting them, you'll need to install Jekyll on your system. Instructions for Windows and macOS are given below:
 
 ### Installing buildroot on Windows
 
- 1. Get Ruby for Windows ([32 bit](//dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.3.3.exe), [64bit](//dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.3.3-x64.exe)), execute the installer and go through the steps of the installation, make sure to check the “Add Ruby executables to your PATH” box.
- 2. Get Ruby Devkit ([32 bit](//dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe), [64bit](//dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe)), the download is a self-extracting archive. When you execute the file, it'll ask you for a destination for the files. Enter a path that has no spaces in it. We recommend something simple, like ` C:\RubyDevKit\` . Click Extract and wait until the process is finished.
- 3. Open your favorite command line tool and do:
-  - `cd C:\RubyDevKit`
-  - `ruby dk.rb init`
-  - `ruby dk.rb install`
-  - `gem install bundler`
+1. Download and install a Ruby+Devkit `3.3.4` from [RubyInstaller Download Archives](//rubyinstaller.org/downloads/archives/). Use default options for installation.
+
+2. Run the `ridk install` step on the last stage of the installation wizard. Choose option `3` for `MSYS2 and MINGW development tool chain`. This is needed for installing gems with native extensions. You can find additional information regarding this in the [RubyInstaller Documentation](//github.com/oneclick/rubyinstaller2#using-the-installer-on-a-target-system).
+
+> [!TIP]
+> Once the `MSYS2 and MINGW development toolchain` install is complete, the installation wizard will reprompt which components should be installed. If you see a "Install MSYS2 and MINGW development toolchain succeeded" message above it, you can close the Command Prompt window and continue below.
+
+3. Open a new Command Prompt so that changes to the `PATH` environment variable become effective, then check that everything is working:
+
+   ```shell
+   ruby -v
+   ```
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x64-mingw-ucrt]` is reported, then proceed to proceed to the [Jekyll primer](#jekyll-primer) section below.
 
 ### Installing buildroot on macOS
 
-Ruby 2.3 or newer is required to use Jekyll, but macOS 10.12 only includes Ruby 2.2. For macOS 10.12 and earlier the custom `rbenv` install described below is required. Even when the OS comes with Ruby 2.3, we still find it easier to use `rbenv` and `ruby-build` to make a self-managed Ruby install.
+> [!NOTE]
+> Ruby may come preinstalled, but macOS' "system Ruby" is outdated, unmaintained, and not recommended for general use.
 
-To install [rbenv](//github.com/rbenv/rbenv) and [ruby-build](//github.com/rbenv/ruby-build#readme) we recommend using one of the popular package managers, [Homebrew](//brew.sh) or [MacPorts](//www.macports.org). (You can also download and install these tools manually.)
+1. Install [Homebrew](//brew.sh/) by launching Terminal and running the following command:
 
-**Important:** Don't install Ruby 2.3 itself using Homebrew/MacPorts/etc., as this leads down a twisty rabbit hole. Either trust the built-in Ruby 2.3 or newer installation or use `rbenv` to do everything. Note that `rbenv` is incompatible with `rvm`, so if you ever installed `rvm` before you'll need to remove it before proceeding.
+   ```shell
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
 
-Once you have `rbenv` and `ruby-build` installed, follow the instructions on the [rbenv](//github.com/rbenv/rbenv) project page to:
+2. Install `chruby`, `ruby-install`, and `xz` with Homebrew:
 
-- install a local version of Ruby (2.3 or newer),
-- modify your `.bash_profile` and `.zprofile` to set your Ruby environment, and
-- create a local `shims` folder with `$PATH` pointing to your Ruby.
+   ```shell
+   brew install chruby ruby-install xz
+   ```
 
-It sounds ugly, but hopefully the instructions on the [rbenv](//github.com/rbenv/rbenv) project page are clear enough to get you that far. You'll be using `rbenv` from now on to install and manage local Ruby environments.
+3. Install Ruby `3.3.4`:
 
-With your Ruby environment set up and ready to go, you can now install the `bundler` Ruby gem with:
-- `gem install bundler`
+   ```shell
+   ruby-install ruby 3.3.4
+   ```
 
-## Jekyll Primer
+   This will take a few minutes. Once the install is complete, configure your shell to automatically use `chruby`:
 
-Under Jekyll we use YAML, Markdown, Liquid, and HTML to fill out the site content and layout. A `_config.yml` file defines the site structure using "collections" that correspond to site sub-folders. The site is "compiled" to produce a static HTML and Javascript file structure. The most important folders are:
+   ```shell
+   echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
+   echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
+   echo "chruby ruby-3.3.4" >> ~/.zshrc
+   ```
+
+4. Quit and relaunch Terminal, then check that everything is working:
+
+   ```shell
+   ruby -v
+   ```
+
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-darwin21]` is reported, proceed to the [Jekyll primer](#jekyll-primer) section below.
+
+### Installing buildroot on Ubuntu
+
+1. Ensure APT is up to date:
+
+   ```shell
+   sudo apt update
+   ```
+2. Install prerequisites:
+
+   ```shell
+   sudo apt install git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+   ```
+
+3. Install rbenv:
+
+   ```shell
+   curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+   echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+   echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+   source ~/.bashrc
+   ```
+
+4. Install Ruby 3.3.4:
+
+   ```shell
+   rbenv install 3.3.4
+   rbenv global 3.3.4
+   ```
+
+4. Check Ruby version:
+
+   ```shell
+   ruby -v
+   ```
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]` is reported, proceed to the next step.
+
+5. Add environment variables to your `~/.bashrc` file to configure the gem installation path:
+
+   ```shell
+   echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
+   echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
+   echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
+   source ~/.bashrc
+   ```
+
+6. Install Bundler Gem:
+
+   ```shell
+   gem install bundler
+   ```
+
+7. Proceed to the [Jekyll primer](#jekyll-primer) section below.
+
+## Jekyll primer
+
+Under Jekyll, we use YAML, Markdown, Liquid, and HTML to fill out the site content and layout. A `_config.yml` file defines the site structure using "collections" that correspond to site sub-folders. The site is "compiled" to produce a static HTML and Javascript file structure. The most important folders are:
 
 - `_layouts` contains the general layouts (aka page templates).
 - `_includes` has partial layouts included by others.
 - `_meta` is where we keep top-level page descriptions.
 - Site sub-pages: `_basics`, `_configuration`, `_development`, `_features`, `_gcode`, `_hardware`.
 
-### Previewing content
+## Previewing content
 
-Now that you have Ruby installed, you'll be able to use Jekyll to preview your changes exactly as they will appear on the final site. Just open a terminal/cmd window, use `chdir` or `cd` to change the working path to your local copy of the repository, and execute the following commands:
+Now that Ruby is installed, you'll be able to use Jekyll to preview your changes exactly as they will appear on the final site. Just open a new Command Prompt or Terminal window, `cd` to change the working path to **your MarlinDocumentation fork**, and execute the following commands:
 
-```
+```shell
 bundle config set path 'vendor/bundle'
 bundle install
+```
+
+> [!NOTE]
+> You'll only need to execute the above commands **once** to install all the required Ruby gems, including Jekyll itself. If you get errors at this stage, you may need to update your Ruby installation, fix your Ruby environment, or resolve dependencies between the Ruby gems.
+
+To start a web server & preview your changes, run the following command:
+
+```shell
 bundle exec jekyll serve --watch --incremental
 ```
 
-You'll only need to execute the `bundle install` command once to install all the required Ruby gems, including Jekyll itself. If you get errors at this stage, you may need to update your Ruby installation, fix your Ruby environment, or resolve dependencies between the Ruby gems.
+With the `serve --watch --incremental` parameters, Jekyll watches local files for changes and triggers an automatic incremental build of the site on every save. It also starts a mini-web server so documentation can be previewed in a browser at [http://localhost:4000/](http://localhost:4000).
 
-With the `serve` option, Jekyll watches the local files and on every save triggers an automatic build of the site. It also runs a mini-webserver at [http://localhost:4000/](//localhost:4000/) so the documentation can be previewed in the browser right on [your own computer](//localhost:4000/).
-
-The main Marlin repository comes with the `mfdoc` script containing the commands above as a shortcut to preview the documentation.
-
-## Publishing changes
-
-We've set up GitHub Actions to run Jekyll and publish to the `gh-pages` branch whenever the `deploy` branch is updated. The `deploy` branch is synchronized from the `master` branch by the project administrator on a semi-regular basis, often just after merging one or more PRs from contributors.
+> [!TIP]
+> The main Marlin repository comes with the [`mfdoc`](//github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/share/git/mfdoc) script containing the commands above as a shortcut to preview the documentation.
 
 ## License
 
-This documentation is licensed under the [Creative Commons Attribution 4.0 International license](//creativecommons.org/licenses/by/4.0/).
+This documentation is licensed under the [GPLv3 license](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -222,14 +222,14 @@ If you'd like to be able to preview your contributions before submitting them, y
 > [!NOTE]
 > When using `rbenv` you'll find your Ruby installations in `~/.rbenv/versions/` and you can switch between them with `rbenv global <version>`.
 
-4. Check Ruby version:
+5. Check Ruby version:
 
    ```sh
    ruby -v
    ```
    If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, proceed to the next step.
 
-5. Add environment variables to your `~/.bashrc` file to configure the gem installation path:
+6. Add environment variables to your `~/.bashrc` file to configure the gem installation path:
 
    ```sh
    echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
@@ -238,13 +238,13 @@ If you'd like to be able to preview your contributions before submitting them, y
    source ~/.bashrc
    ```
 
-6. Install Bundler Gem:
+7. Install Bundler Gem:
 
    ```sh
    gem install bundler
    ```
 
-7. Proceed to **Installing Jekyll**….
+8. Proceed to **Installing Jekyll**….
 
 ### Installing Jekyll
 

--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ If you'd like to be able to preview your contributions before submitting them, y
 
      - Either Xcode or Command Line Tools for Xcode are required to install packages with MacPorts. You **do not** need to install both. These are available for free on [Apple's Developer Program website](https://developer.apple.com/download/). An Apple Developer Program membership is not required, but you will need to sign in with your Apple ID.
 
-2. Install `chruby`, `ruby-install`, and `xz`:
+2. Install `chruby` and `ruby-install`:
 
    - Homebrew:
 
      ```sh
-     brew install chruby ruby-install xz
+     brew install chruby ruby-install
      ```
 
    - MacPorts:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    - MacPorts:
 
      ```sh
-     sudo port install chruby ruby-install xz
+     sudo port install chruby ruby-install
      ```
 
 3. Install Ruby `3.3.4`:
@@ -152,7 +152,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ruby-install ruby 3.3.4
    ```
 
-   This will take a few minutes. (It's not as quick as the `rbenv` install you may have used previously.)
+   The configure, build, and install process will take a few minutes.
 
 4. Configure your shell to automatically use `chruby`:
 
@@ -183,6 +183,9 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```
 
    It should report `ruby 3.3.4 (2024-07-09 revision be1089c8ec)`. If not, repeat the above steps.
+
+> [!NOTE]
+> When using `ruby-install` you'll find your Ruby installations in `~/.rubies/` and you can switch between them with `chruby`. New instances of `zsh` in Terminal will default to 3.3.4 due to the changes made to `~/.zshrc`.
 
 6. Proceed to the [Installing Jekyll](#installing-jekyll) section below. (Note that `bundler` is already included.)
 
@@ -216,6 +219,9 @@ If you'd like to be able to preview your contributions before submitting them, y
    rbenv global 3.3.4
    ```
 
+> [!NOTE]
+> When using `rbenv` you'll find your Ruby installations in `~/.rbenv/versions/` and you can switch between them with `rbenv global <version>`.
+
 4. Check Ruby version:
 
    ```sh
@@ -238,7 +244,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    gem install bundler
    ```
 
-7. Proceed to Installing Jekyll….
+7. Proceed to **Installing Jekyll**….
 
 ### Installing Jekyll
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 <h1 align="center">Marlin Documentation Project</h1>
 
 <p align="center">
-  <a href="/LICENSE"><img alt="GPL-V3.0 License" src="https://img.shields.io/github/license/MarlinFirmware/MarlinDocumentation.svg"></a>
-  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/marlinfirmware/marlindocumentation.svg"></a>
-  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/releases"><img alt="Last Updated" src="https://img.shields.io/github/last-commit/marlinfirmware/marlindocumentation?label=last%20updated"></a>
-  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml"><img alt="Jekyll Deploy Status" src="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml/badge.svg"></a>
-  <a href="https://github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
+  <a href="/LICENSE" target="_blank"><img alt="GPL-V3.0 License" src="https://img.shields.io/github/license/MarlinFirmware/MarlinDocumentation.svg"></a>
+  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/graphs/contributors" target="_blank"><img alt="Contributors" src="https://img.shields.io/github/contributors/marlinfirmware/marlindocumentation.svg"></a>
+  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/releases" target="_blank"><img alt="Last Updated" src="https://img.shields.io/github/last-commit/marlinfirmware/marlindocumentation?label=last%20updated"></a>
+  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml" target="_blank"><img alt="Jekyll Deploy Status" src="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml/badge.svg"></a>
+  <a href="https://github.com/sponsors/thinkyhead" target="_blank"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
   <br />
-  <a href="https://x.com/marlinfirmware"><img src="https://img.shields.io/twitter/follow/marlinfirmware?logo=x&style=for-the-badge" alt="@MarlinFirmware" /></a>
-  <a href="https://fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
+  <a href="https://x.com/marlinfirmware" target="_blank"><img src="https://img.shields.io/twitter/follow/MarlinFirmware" alt="@MarlinFirmware" /></a>
+  <a href="https://fosstodon.org/@marlinfirmware" target="_blank"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
 </p>
 
 ## About

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```sh
    ruby -v
    ```
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Set up Marlin Documentation project](#set-up-marlin-documentation-project) section below.
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to [Set up the Marlin Documentation project](#set-up-marlin-documentation-project).
 
 ### Installing Ruby on macOS
 
@@ -181,13 +181,12 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```sh
    ruby -v
    ```
-
    It should report `ruby 3.3.4 (2024-07-09 revision be1089c8ec)`. If not, repeat the above steps.
 
 > [!NOTE]
 > When using `ruby-install` you'll find your Ruby installations in `~/.rubies/` and you can switch between them with `chruby`. New instances of `zsh` in Terminal will default to 3.3.4 due to the changes made to `~/.zshrc`.
 
-6. Proceed to the [Set up Marlin Documentation project](#set-up-marlin-documentation-project) section below. (Note that `bundler` is already included.)
+6. Proceed to [Set up the Marlin Documentation project](#set-up-marlin-documentation-project). (Note that `bundler` is already included.)
 
 ### Installing Ruby on Ubuntu
 
@@ -227,7 +226,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```sh
    ruby -v
    ```
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, proceed to the next step.
+   It should report `ruby 3.3.4 (2024-07-09 revision be1089c8ec)`. If not, repeat the above steps.
 
 6. Add environment variables to your `~/.bashrc` file to configure the gem installation path:
 
@@ -244,7 +243,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    gem install bundler
    ```
 
-8. Proceed to **Installing Jekyll**….
+8. Proceed to **Set up Marlin Documentation project**.
 
 ### Set up Marlin Documentation project
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml"><img alt="Jekyll Deploy Status" src="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml/badge.svg"></a>
   <a href="https://github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
   <br />
-  <a href="https://twitter.com/MarlinFirmware?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @MarlinFirmware</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <a href="https://x.com/marlinfirmware"><img src="https://img.shields.io/twitter/follow/marlinfirmware?logo=x&style=for-the-badge" alt="@MarlinFirmware" /></a>
   <a href="https://fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-<p align="center"><img src="https://raw.githubusercontent.com/MarlinFirmware/Marlin/bugfix-2.1.x/buildroot/share/pixmaps/logo/marlin-outrun-nf-500.png" height="250" alt="MarlinFirmware's logo" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/MarlinFirmware/Marlin/bugfix-2.1.x/buildroot/share/pixmaps/logo/marlin-outrun-nf-500.png" height="250" alt="Marlin Firmware logo" /></p>
 
 <h1 align="center">Marlin Documentation Project</h1>
 
 <p align="center">
-    <a href="/LICENSE"><img alt="GPL-V3.0 License" src="https://img.shields.io/github/license/MarlinFirmware/MarlinDocumentation.svg"></a>
-    <a href="//github.com/MarlinFirmware/MarlinDocumentation/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/marlinfirmware/marlindocumentation.svg"></a>
-    <a href="//github.com/MarlinFirmware/MarlinDocumentation/releases"><img alt="Last Updated" src="https://img.shields.io/github/last-commit/marlinfirmware/marlindocumentation?label=last%20updated"></a>
-    <a href="//github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml"><img alt="Jekyll Deploy Status" src="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml/badge.svg"></a>
-    <a href="//github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
-    <br />
-    <a href="//fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
+  <a href="/LICENSE"><img alt="GPL-V3.0 License" src="https://img.shields.io/github/license/MarlinFirmware/MarlinDocumentation.svg"></a>
+  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/marlinfirmware/marlindocumentation.svg"></a>
+  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/releases"><img alt="Last Updated" src="https://img.shields.io/github/last-commit/marlinfirmware/marlindocumentation?label=last%20updated"></a>
+  <a href="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml"><img alt="Jekyll Deploy Status" src="https://github.com/MarlinFirmware/MarlinDocumentation/actions/workflows/jekyll-pub.yml/badge.svg"></a>
+  <a href="https://github.com/sponsors/thinkyhead"><img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/thinkyhead?color=db61a2"></a>
+  <br />
+  <a href="https://twitter.com/MarlinFirmware?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @MarlinFirmware</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <a href="https://fosstodon.org/@marlinfirmware"><img alt="Follow MarlinFirmware on Mastodon" src="https://img.shields.io/mastodon/follow/109450200866020466?domain=https%3A%2F%2Ffosstodon.org&logoColor=%2300B&style=social"></a>
 </p>
 
 ## About
@@ -68,7 +69,7 @@ git checkout master -b doc-mashed_potatoes
 
 Inside the `_docs` folder, add the new file `mashed-potatoes.md` and let flow all your creativity into it. When you feel your masterpiece is ready to be shared with the world, commit the changes and push them up to **your MarlinDocumentation fork**. This is done most easily from within the GitHub Desktop app, but here are the command line commands for reference:
 
-```shell
+```sh
 git add mashed-potatoes.md
 git commit -m "Added a new document about potatoes"
 git push
@@ -106,7 +107,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 3. Open a new Command Prompt so that changes to the `PATH` environment variable become effective, then check that everything is working:
 
-   ```shell
+   ```sh
    ruby -v
    ```
    If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Jekyll primer](#jekyll-primer) section below.
@@ -122,7 +123,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 
    - Install Homebrew by launching Terminal and running the following command:
 
-      ```shell
+      ```sh
       /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       ```
 
@@ -134,19 +135,19 @@ If you'd like to be able to preview your contributions before submitting them, y
 
    - Homebrew:
 
-      ```shell
+      ```sh
       brew install chruby ruby-install xz
       ```
 
    - MacPorts:
 
-     ```shell
+     ```sh
      sudo port install chruby ruby-install xz
      ```
 
 3. Install Ruby `3.3.4`:
 
-   ```shell
+   ```sh
    ruby-install ruby 3.3.4
    ```
 
@@ -156,7 +157,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 
    - Homebrew:
 
-     ```shell
+     ```sh
      echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
      echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
      echo "chruby ruby-3.3.4" >> ~/.zshrc
@@ -164,7 +165,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 
    - MacPorts:
 
-     ```shell
+     ```sh
      echo "source ${prefix}/opt/local/share/chruby/chruby.sh" >> ~/.zshrc
      echo "source ${prefix}/opt/local/share/chruby/auto.sh" >> ~/.zshrc
      echo "chruby ruby-3.3.4" >> ~/.zshrc
@@ -172,7 +173,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 5. Quit and relaunch Terminal, then check that everything is working:
 
-   ```shell
+   ```sh
    ruby -v
    ```
 
@@ -182,18 +183,18 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 1. Ensure APT is up to date:
 
-   ```shell
+   ```sh
    sudo apt update
    ```
 2. Install prerequisites:
 
-   ```shell
+   ```sh
    sudo apt install git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
    ```
 
 3. Install rbenv:
 
-   ```shell
+   ```sh
    curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
    echo 'eval "$(rbenv init -)"' >> ~/.bashrc
@@ -202,21 +203,21 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 4. Install Ruby 3.3.4:
 
-   ```shell
+   ```sh
    rbenv install 3.3.4
    rbenv global 3.3.4
    ```
 
 4. Check Ruby version:
 
-   ```shell
+   ```sh
    ruby -v
    ```
    If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, proceed to the next step.
 
 5. Add environment variables to your `~/.bashrc` file to configure the gem installation path:
 
-   ```shell
+   ```sh
    echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
    echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
    echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
@@ -225,7 +226,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 6. Install Bundler Gem:
 
-   ```shell
+   ```sh
    gem install bundler
    ```
 
@@ -244,7 +245,7 @@ Under Jekyll, we use YAML, Markdown, Liquid, and HTML to fill out the site conte
 
 Now that Ruby is installed, you'll be able to use Jekyll to preview your changes exactly as they will appear on the final site. Just open a new Command Prompt or Terminal window, `cd` to change the working path to **your MarlinDocumentation fork**, and execute the following commands:
 
-```shell
+```sh
 bundle config set path 'vendor/bundle'
 bundle install
 ```
@@ -254,7 +255,7 @@ bundle install
 
 To start a web server & preview your changes, run the following command:
 
-```shell
+```sh
 bundle exec jekyll serve --watch --incremental
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the raw documentation for [Marlin 3D printer firmware](
   - [Installing Ruby on Windows](#installing-ruby-on-windows)
   - [Installing Ruby on macOS](#installing-ruby-on-macos)
   - [Installing Ruby on Ubuntu](#installing-ruby-on-ubuntu)
-  - [Installing Jekyll](#installing-jekyll)
+  - [Set up Marlin Documentation project](#set-up-marlin-documentation-project)
   - [Jekyll basics](#jekyll-basics)
   - [Previewing content](#previewing-content)
   - [License](#license)
@@ -68,7 +68,7 @@ If your new document is about "mashed potatoes" then name the new branch accordi
 git checkout master -b doc-mashed_potatoes
 ```
 
-Inside the `_docs` folder, add the new file `mashed-potatoes.md` and let flow all your creativity into it. When you feel your masterpiece is ready to be shared with the world, commit the changes and push them up to **your MarlinDocumentation fork**. This is done most easily from within the GitHub Desktop app, but here are the command line commands for reference:
+Inside the `_docs` folder, add the new file `mashed-potatoes.md` and let flow all your creativity into it. When you feel your masterpiece is ready to be shared with the world, commit the changes and push them up to **your Marlin Documentation fork**. This is done most easily from within the GitHub Desktop app, but here are the command line commands for reference:
 
 ```sh
 git add mashed-potatoes.md
@@ -111,7 +111,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```sh
    ruby -v
    ```
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Installing Jekyll](#installing-jekyll) section below.
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Set up Marlin Documentation project](#set-up-marlin-documentation-project) section below.
 
 ### Installing Ruby on macOS
 
@@ -187,7 +187,7 @@ If you'd like to be able to preview your contributions before submitting them, y
 > [!NOTE]
 > When using `ruby-install` you'll find your Ruby installations in `~/.rubies/` and you can switch between them with `chruby`. New instances of `zsh` in Terminal will default to 3.3.4 due to the changes made to `~/.zshrc`.
 
-6. Proceed to the [Installing Jekyll](#installing-jekyll) section below. (Note that `bundler` is already included.)
+6. Proceed to the [Set up Marlin Documentation project](#set-up-marlin-documentation-project) section below. (Note that `bundler` is already included.)
 
 ### Installing Ruby on Ubuntu
 
@@ -246,9 +246,9 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 8. Proceed to **Installing Jekyll**….
 
-### Installing Jekyll
+### Set up Marlin Documentation project
 
-Once Ruby is installed you'll need to install Jekyll itself. Open the Command Prompt or Terminal and `cd` to the working path of **your MarlinDocumentation fork**. Execute the following commands:
+Once Ruby is installed, set up the Marlin Documentation project with Bundler. Open Command Prompt or Terminal and `cd` to the working path of **your Marlin Documentation fork**. Execute the following commands:
 
 ```sh
 rm -f Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -115,18 +115,34 @@ If you'd like to be able to preview your contributions before submitting them, y
 
 > [!NOTE]
 > Ruby may come preinstalled, but macOS' "system Ruby" is outdated, unmaintained, and not recommended for general use.
+>
+> There are many popular package managers for macOS, but we'll cover installation with [Homebrew](//brew.sh/) & [MacPorts](//www.macports.org/).
 
-1. Install [Homebrew](//brew.sh/) by launching Terminal and running the following command:
+1. Install a package manager. You **do not** need to install both:
 
-   ```shell
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-   ```
+   - Install Homebrew by launching Terminal and running the following command:
 
-2. Install `chruby`, `ruby-install`, and `xz` with Homebrew:
+      ```shell
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      ```
 
-   ```shell
-   brew install chruby ruby-install xz
-   ```
+   - Install MacPorts by downloading & installing the correct package for your version of macOS from the [Installing MacPorts](//www.macports.org/install.php) page.
+
+     - Either Xcode or Command Line Tools for Xcode are required to install packages with MacPorts. You **do not** need to install both. These are available for free on [Apple's Developer Program website](https://developer.apple.com/download/). An Apple Developer Program membership is not required, but you will need to sign in with your Apple ID.
+
+2. Install `chruby`, `ruby-install`, and `xz`:
+
+   - Homebrew:
+
+      ```shell
+      brew install chruby ruby-install xz
+      ```
+
+   - MacPorts:
+
+     ```shell
+     sudo port install chruby ruby-install xz
+     ```
 
 3. Install Ruby `3.3.4`:
 
@@ -134,15 +150,27 @@ If you'd like to be able to preview your contributions before submitting them, y
    ruby-install ruby 3.3.4
    ```
 
-   This will take a few minutes. Once the install is complete, configure your shell to automatically use `chruby`:
+   This will take a few minutes.
 
-   ```shell
-   echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
-   echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
-   echo "chruby ruby-3.3.4" >> ~/.zshrc
-   ```
+4. Configure your shell to automatically use `chruby`:
 
-4. Quit and relaunch Terminal, then check that everything is working:
+   - Homebrew:
+
+     ```shell
+     echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
+     echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
+     echo "chruby ruby-3.3.4" >> ~/.zshrc
+     ```
+
+   - MacPorts:
+
+     ```shell
+     echo "source ${prefix}/opt/local/share/chruby/chruby.sh" >> ~/.zshrc
+     echo "source ${prefix}/opt/local/share/chruby/auto.sh" >> ~/.zshrc
+     echo "chruby ruby-3.3.4" >> ~/.zshrc
+     ```
+
+5. Quit and relaunch Terminal, then check that everything is working:
 
    ```shell
    ruby -v

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```shell
    ruby -v
    ```
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x64-mingw-ucrt]` is reported, then proceed to proceed to the [Jekyll primer](#jekyll-primer) section below.
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, then proceed to proceed to the [Jekyll primer](#jekyll-primer) section below.
 
 ### Installing buildroot on macOS
 
@@ -148,7 +148,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ruby -v
    ```
 
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-darwin21]` is reported, proceed to the [Jekyll primer](#jekyll-primer) section below.
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, proceed to the [Jekyll primer](#jekyll-primer) section below.
 
 ### Installing buildroot on Ubuntu
 
@@ -184,7 +184,7 @@ If you'd like to be able to preview your contributions before submitting them, y
    ```shell
    ruby -v
    ```
-   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]` is reported, proceed to the next step.
+   If `ruby 3.3.4 (2024-07-09 revision be1089c8ec)` is reported, proceed to the next step.
 
 5. Add environment variables to your `~/.bashrc` file to configure the gem installation path:
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -61,7 +61,7 @@
   --color-gcode-related: #000;
   --color-gcode-related-bg: #DDD;
   --color-h1-gcode: #B88;
-  --color-h1-basic: #8B8;
+  --color-h1-basics: #8B8;
   --color-h1-feat: #8BB;
   --color-h1-hardware: #88B;
   --color-h1-devel: #BB8;
@@ -243,7 +243,7 @@
   --color-gcode-related: #FFF;
   --color-gcode-related-bg: #222;
   --color-h1-gcode: #B88;
-  --color-h1-basic: #8B8;
+  --color-h1-basics: #8B8;
   --color-h1-feat: #8BB;
   --color-h1-hardware: #88B;
   --color-h1-devel: #BB8;


### PR DESCRIPTION
As the title states, completely overhaul the repository README.

The main focus (and entire reason I started down this path) was to add *tested* and *working* Ruby & Jekyll install procedures for local development/preview since the current instructions were woefully out of date and did not work.

This involved setting up new VMs for Windows 10, macOS 12.7.6 (limited by my hardware), & Ubuntu 24.04 LTS and validating each step to work out any bugs. After working out the steps & commands, VMs were reset to a fresh state & the updated Ruby/Jekyll install process was verified to work without issue.

H/t to @ellensp for being a sounding board while I bashed my head against the wall working through these issues.