### PR TITLE
📝 Update Discord links

### DIFF
--- a/_basics/install_platformio_vscode.md
+++ b/_basics/install_platformio_vscode.md
@@ -19,7 +19,7 @@ Visit the [Setting up Visual Studio Code](//code.visualstudio.com/docs/setup/set
 
 You can download the latest Marlin source code from the [Downloads](/meta/download/) page. Older versions and detailed Release Notes can be downloaded from the [Marlin Releases](//github.com/MarlinFirmware/Marlin/releases) page on GitHub.
 
-The 'latest' version might not always be the 'greatest' version for your setup. Be sure to ask around in our [Discord community](//discord.gg/marlin-firmware-461605380783472640) if you need assistance with any version of Marlin Firmware.
+The 'latest' version might not always be the 'greatest' version for your setup. Be sure to ask around in our [Discord community](//discord.com/servers/marlin-firmware-461605380783472640) if you need assistance with any version of Marlin Firmware.
 
 ### 3. Install PlatformIO IDE
 

--- a/_basics/reporting_bugs.md
+++ b/_basics/reporting_bugs.md
@@ -70,7 +70,7 @@ In addition to following the guidelines above, we ask that you follow a thorough
   - [Issue Queue](//github.com/MarlinFirmware/Marlin/issues)
   - [Post a New Issue](//github.com/MarlinFirmware/Marlin/issues/new?labels=Bug%3A+Potential+%3F&template=bug_report.yml&title=%5BBUG%5D+%28bug+summary%29)
   - [Bug Fix branch](//github.com/MarlinFirmware/Marlin/tree/bugfix-2.1.x)
-  - [MarlinFirmware on Discord](//discord.gg/marlin-firmware-461605380783472640) - Realtime chat with users and developers
+  - [MarlinFirmware on Discord](//discord.com/servers/marlin-firmware-461605380783472640) - Realtime chat with users and developers
   - [Marlin Firmware](//www.facebook.com/groups/1049718498464482/) and [Marlin Firmware for 3D Printers](//www.facebook.com/groups/3Dtechtalk/) Facebook Groups
   - [Marlin Forum](//forums.reprap.org/list.php?415) at RepRap.org
   - [Marlin YouTube Videos](//youtube.com/results?search_query=marlin+firmware)

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ social:
     - https://fosstodon.org/@marlinfirmware
     - https://www.facebook.com/groups/1049718498464482/
     - http://forums.reprap.org/list.php?415
-    - https://discord.gg/marlin-firmware-461605380783472640
+    - https://discord.com/servers/marlin-firmware-461605380783472640
 
 repository:
   main: 'https://github.com/MarlinFirmware/Marlin'

--- a/_configuration/config-ini.md
+++ b/_configuration/config-ini.md
@@ -18,7 +18,7 @@ Marlin configurations include `#if` blocks to group dependent options, although 
 
 It can be tricky to migrate from older versions of Marlin as settings change. Marlin checks for old settings and tells you what to change during the build, but the final result is never fully up to date. Wouldn't it be nice if Marlin would automatically migrate old settings to a new configuration for you?
 
-We're currently working on tools to improve the situation, with the goal to build a schema and a database of configurations across all Marlin versions so we can generate complete configuration headers, perform migrations, and even generate searchable documentation for this website. That is a big project unto itself, so feel free to [get involved on Discord](https://discord.gg/marlin-firmware-461605380783472640)!
+We're currently working on tools to improve the situation, with the goal to build a schema and a database of configurations across all Marlin versions so we can generate complete configuration headers, perform migrations, and even generate searchable documentation for this website. That is a big project unto itself, so feel free to [get involved on Discord](https://discord.com/servers/marlin-firmware-461605380783472640)!
 
 ## Meta Configuration
 

--- a/_development/contributing.md
+++ b/_development/contributing.md
@@ -15,7 +15,7 @@ The core Marlin team consists of a few maintainers who review contributions, dis
 ## Ways to contribute
 
 ### Donate
-The current maintainer of Marlin is [Scott Lahteine](//www.thinkyhead.com/donate-to-marlin) aka [@thinkyhead](https://github.com/thinkyhead/). Scott has been writing software since 1977 mostly focusing on shareware and open source. He reviews every contribution before it goes into Marlin, maintains documentation, hosts the [Facebook](https://www.facebook.com/groups/marlinfirmware) and [Marlin Discord](https://discord.gg/marlin-firmware-461605380783472640), and maintains a test lab in Austin, TX.
+The current maintainer of Marlin is [Scott Lahteine](//www.thinkyhead.com/donate-to-marlin) aka [@thinkyhead](https://github.com/thinkyhead/). Scott has been writing software since 1977 mostly focusing on shareware and open source. He reviews every contribution before it goes into Marlin, maintains documentation, hosts the [Facebook](https://www.facebook.com/groups/marlinfirmware) and [Marlin Discord](https://discord.com/servers/marlin-firmware-461605380783472640), and maintains a test lab in Austin, TX.
 
 Your sponsorship accelerates development, testing, and advancement of the most ambitious open source multi-platform 3D printing firmware in the world. Several support options are available:
 
@@ -50,7 +50,7 @@ Are you skilled in information design? This website is far from complete, and it
 
 There are now many community resources for users of Marlin. If you're looking for help installing or troubleshooting these are the best places to go.
 
-- [MarlinFirmware on Discord](//discord.gg/marlin-firmware-461605380783472640) - Realtime chat with users and developers
+- [MarlinFirmware on Discord](//discord.com/servers/marlin-firmware-461605380783472640) - Realtime chat with users and developers
 - [Marlin Firmware](//www.facebook.com/groups/1049718498464482/) and [Marlin Firmware for 3D Printers](//www.facebook.com/groups/3Dtechtalk/) Facebook Groups
 - [Marlin Forum](//forums.reprap.org/list.php?415) at RepRap.org
 - [Marlin YouTube Videos](//youtube.com/results?search_query=marlin+firmware)

--- a/_meta/releases.html
+++ b/_meta/releases.html
@@ -33,7 +33,7 @@ blurb: |
   - The `2.1.x` branch will be copied to `lts-2.1.3` and branch `2.1.x` will go dormant.
 
   The release process will work like this:
-  - Ahead of each release we'll make a snapshot of `dev` as a pre-release intended only for testers and announce it on [Discord](//discord.gg/marlin-firmware-461605380783472640).
+  - Ahead of each release we'll make a snapshot of `dev` as a pre-release intended only for testers and announce it on [Discord](//discord.com/servers/marlin-firmware-461605380783472640).
   - During the testing period all development within `dev` will take the lead from the pre-release branch, so nothing will go into `dev` that isn't also going into the pending release. New features and other non-bug-fixing PRs will be held during this period.
   - Once the pre-release is certified by testers (or at least hasn't exploded dramatically) it will be tagged and released to the world.
   - Releases may be followed up with "fixup" patches within the first week after a release. Volunteer testers catch a lot of bugs, but they don't always catch 'em all!

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ category:     [ default ]
           <div class="panel-body">Contribute to our ever expanding open source Marlin project on GitHub!</div>
         </div>
       </a>
-      <a class="col-sm-4 animation-element slide-up panel-wrapper" href="//discord.gg/marlin-firmware-461605380783472640">
+      <a class="col-sm-4 animation-element slide-up panel-wrapper" href="//discord.com/servers/marlin-firmware-461605380783472640">
         <div class="panel">
           <div class="panel-heading panel-discord"><h4><em class="fa-brands fa-discord" aria-hidden="true"></em> Join Our Discord</h4></div>
           <div class="panel-body">Get help, chat, and share with other Marlin users on our Discord channel.</div>


### PR DESCRIPTION
### Description

Point to server landing page instead of invite link so users can read about the server before joining.

### Benefits

All Discord links between here & main MarlinFirmware/Marlin repo will now use the same URL.

### Related Issues
- https://github.com/MarlinFirmware/Marlin/pull/27330
- 04f0c9c