### PR TITLE
Fixes "Calibration of your RepRap" link via WebArchive

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -41,7 +41,7 @@ If you've never configured and calibrated a 3D Printer before, here are some goo
 - [Průša's calculators](//blog.prusaprinters.org/calculator_3416/)
 - [Triffid Hunter's Calibration Guide](//reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide)
 - [The Essential Calibration Set](//www.thingiverse.com/thing:5573)
-- [Calibration of your RepRap (Internet Archive link)](//web.archive.org/web/20220907014303/https://sites.google.com/site/repraplogphase/calibration-of-your-reprap)
+- [Calibration of your RepRap](//web.archive.org/web/20220907014303/sites.google.com/site/repraplogphase/calibration-of-your-reprap)
 - [XY 20mm Calibration Box](//www.thingiverse.com/thing:298812)
 - [G-code reference](//reprap.org/wiki/G-code)
 - [Marlin3DprinterTool](//github.com/cabbagecreek/Marlin3DprinterTool)

--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -41,7 +41,7 @@ If you've never configured and calibrated a 3D Printer before, here are some goo
 - [Průša's calculators](//blog.prusaprinters.org/calculator_3416/)
 - [Triffid Hunter's Calibration Guide](//reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide)
 - [The Essential Calibration Set](//www.thingiverse.com/thing:5573)
-- [Calibration of your RepRap](//sites.google.com/site/repraplogphase/calibration-of-your-reprap)
+- [Calibration of your RepRap (Internet Archive link)](//web.archive.org/web/20220907014303/https://sites.google.com/site/repraplogphase/calibration-of-your-reprap)
 - [XY 20mm Calibration Box](//www.thingiverse.com/thing:298812)
 - [G-code reference](//reprap.org/wiki/G-code)
 - [Marlin3DprinterTool](//github.com/cabbagecreek/Marlin3DprinterTool)

--- a/_hardware/controllers.md
+++ b/_hardware/controllers.md
@@ -118,7 +118,7 @@ groups:
 
     - name: RA_CONTROL_PANEL
       description: Elefu RA board control panel.
-      url: web.archive.org/web/20140823033947/http://www.elefu.com/index.php?route=product/product&product_id=53
+      url: web.archive.org/web/20140823033947/www.elefu.com/index.php?route=product/product&product_id=53
       interface: I2C
 
     - name: LCD_SAINSMART_I2C_1602


### PR DESCRIPTION
The link to "Calibration of your RepRap" was directed to a now-offline webpage. Fortunately, there is a copy of it hosted by the Internet Archive. This link now directs to that instead.