### PR TITLE
📝 Update Input Shaping docs

### DIFF
--- a/_features/input_shaping.md
+++ b/_features/input_shaping.md
@@ -35,7 +35,7 @@ The frequency of the anti-vibration signal will correspond to the *natural frequ
 
 Marlin first introduced *ZV Input Shaping* in version 2.1.2. More advanced input shapers may be able to cancel more complex acoustic waves, but even this simple shaper can make a striking improvement in print quality and speed. It's also so efficient that it can run on AVR, bringing Input Shaping to millions of existing 3D printers with no change of hardware.
 
-This simple shaper introduces a single anti-vibration signal into the stepper motion for the X and Y axes. It does this at the stepper level by doing normal stepping with 1/2 of the step count at half the frequency, then introducing a second set of step signals that "echo" the first, delayed by 1/2 of the ringing interval. It is a simple and elegant trick, and best of all, it works!
+This simple shaper introduces a single anti-vibration signal into the stepper motion for the X, Y, and Z axes. It does this at the stepper level by doing normal stepping with 1/2 of the step count at half the frequency, then introducing a second set of step signals that "echo" the first, delayed by 1/2 of the ringing interval. It is a simple and elegant trick, and best of all, it works!
 
 This input shaper is controlled with G-code [`M593`](/docs/gcode/M593.html).
 

--- a/_gcode/M593.md
+++ b/_gcode/M593.md
@@ -5,7 +5,7 @@ brief: Get or set Marlin's integrated ZV Input Shaping parameters
 author: thinkyhead
 
 since: 2.1.2
-requires: INPUT_SHAPING_[XY]
+requires: INPUT_SHAPING_[XYZ]
 group: motion
 
 codes: [ M593 ]
@@ -15,27 +15,33 @@ parameters:
 
 - tag: D
   optional: true
-  description: Set the zeta/damping factor for the specified axes. If `X` and `Y` are omitted, both will be set.
+  description: Set the zeta/damping factor for the specified axes. If `X`, `Y`, and `Z` are omitted, all will be set.
   values:
   - type: float
     tag: zeta
 
 - tag: F
   optional: true
-  description: Set the damping frequency for the specified axes. If `X` and `Y` are omitted, both will be set.
+  description: Set the damping frequency for the specified axes. If `X`, `Y`, and `Z` are omitted, all will be set.
   values:
   - type: float
     tag: hertz
 
 - tag: X
   optional: true
-  description: Flag to set the X axis value. If `X` and `Y` are omitted, both will be set.
+  description: Flag to set the X axis value.
   values:
   - type: flag
 
 - tag: Y
   optional: true
-  description: Flag to set the Y axis value. If `X` and `Y` are omitted, both will be set.
+  description: Flag to set the Y axis value.
+  values:
+  - type: flag
+
+- tag: Z
+  optional: true
+  description: Flag to set the Z axis value.
   values:
   - type: flag
 
@@ -48,7 +54,7 @@ examples:
 - pre: Set the frequency for X to 18.4Hz
   code: M593 X F18.4
 
-- pre: Set the frequency for X and Y to 36.2Hz
+- pre: Set the frequency for X, Y, and Z to 36.2Hz
   code: M593 F36.2
 
 - pre: Disable Input Shaping

--- a/_gcode/M593.md
+++ b/_gcode/M593.md
@@ -40,6 +40,7 @@ parameters:
   - type: flag
 
 - tag: Z
+  since: 2.1.3
   optional: true
   description: Flag to set the Z axis value.
   values:

--- a/_gcode/M593.md
+++ b/_gcode/M593.md
@@ -7,7 +7,6 @@ author: thinkyhead
 since: 2.1.2
 requires: INPUT_SHAPING_[XY]
 group: motion
-experimental: true
 
 codes: [ M593 ]
 related: [ M493 ]


### PR DESCRIPTION
### Description

- Input Shaping's "Experimental" tag was removed in https://github.com/MarlinFirmware/Marlin/commit/83cbed852791805da0417f930cce3f2373b2eca2, so remove it from here too.
- Add Z parameter

Related to this, Marlin's [Input Shaping Calibration Pattern tool]( https://marlinfw.org/tools/input_shaping/freq-calibr.html) still needs an update to support the Z axis.

### Related Issues
- https://github.com/MarlinFirmware/Marlin/commit/83cbed852791805da0417f930cce3f2373b2eca2
- https://github.com/MarlinFirmware/Marlin/pull/27073