### PR TITLE
✏️  Fix wrong example snippet for M109

### DIFF
--- a/_gcode/M109.md
+++ b/_gcode/M109.md
@@ -68,7 +68,7 @@ examples:
   code: M109 R120
 
 - pre: Set target temperature for E1 and wait (if heating up)
-  code: M109 T1 R205
+  code: M109 T1 S205
 
 - pre: '`AUTOTEMP`: Set autotemp range, wait for temp'
   code: M109 F S180 B190


### PR DESCRIPTION
Hey there! 🖖 

The [M109 gcode documentation](https://marlinfw.org/docs/gcode/M109.html) states:

> `[R<temp>]`
> Target temperature (wait for **cooling or heating**).
>
>`[S<temp>]`
> Target temperature (wait **only when heating**).

But there is an example on the same page where it says the `R` will wait `if heating up`, not mentioning the `or cooling` part of the conditional:
> Set target temperature for E1 and wait **(if heating up)**
> `M109 T1 R205`

I believe `S<temp>` was meant instead of `R<temp>`, or the `or cooling` part was forgotten, which is a bit confusing when reading the examples. 