### PR TITLE
update S and X|Y tags on M493

### DIFF
--- a/_gcode/M493.md
+++ b/_gcode/M493.md
@@ -16,28 +16,33 @@ parameters:
 
 - tag: S
   optional: true
-  description: Set the current motion mode and/or Input Shaper.
+  description: Set Fixed-Time motion mode OFF (0) / ON (1).
+  values:
+  - tag: bool
+
+- tag: X|Y
+  optional: true
+  description: Set the vibration compensator [input shaper] mode for X / Y axis. Note.
+    Users and slicers must remember to set the mode for both axes!
   values:
   - tag: 0
-    description: Standard Motion
+    description: NONE (No input shaper)
   - tag: 1
-    description: Fixed-Time Motion
-  - tag: 10
-    description: ZV Input Shaping
-  - tag: 11
-    description: ZVD Input Shaping
-  - tag: 12
-    description: ZVDD Input Shaping
-  - tag: 13
-    description: ZVDDD Input Shaping
-  - tag: 14
-    description: EI Input Shaping
-  - tag: 15
-    description: 2HEI Input Shaping
-  - tag: 16
-    description: 3HEI Input Shaping
-  - tag: 17
-    description: MZV Input Shaping
+    description: ZV (Zero Vibration)
+  - tag: 2
+    description: ZVD (Zero Vibration and Derivative)
+  - tag: 3
+    description: ZVDD (Zero Vibration, Derivative, and Double Derivative)
+  - tag: 4
+    description: ZVDDD (Zero Vibration, Derivative, Double Derivative, and Triple Derivative)
+  - tag: 5
+    description: EI (Extra-Intensive)
+  - tag: 6
+    description: 2HEI (2-Hump Extra-Intensive)
+  - tag: 7
+    description: 3HEI (3-Hump Extra-Intensive)
+  - tag: 8
+    description: MZV (Mass-based Zero Vibration)
 
 - tag: P
   optional: true
@@ -98,7 +103,7 @@ example:
   code: M493 S1 P1 K0.22
 
 - pre: Enable Fixed-Time motion with ZVD Input Shaping
-  code: M493 S11 A37 B37 D0 P1 K0.18
+  code: M493 S1 X2 Y2 A37 B37 D0 P1 K0.18
   post: This also sets the IS Frequency to 37Hz for X and Y, disables Dynamic Frequency mode, and enables Linear Advance with a gain of 0.18.
 
 ---
@@ -119,7 +124,7 @@ Use a slicer that provides custom G-code macros for layer change. For example yo
 
 - In the the Starting G-code enable Fixed-Time Motion with something like:
   ```
-  M493 S11 D0 ; Enable ZVD Input Shaping
+  M493 S1 X2 Y2 D0 ; Enable ZVD Input Shaping
   ```
 
 - In *Kiri:Moto* enable **Infill > Fill Type > Vase**. Then add the following under **Setup > Machine > Gcode Macros > Layer** to run a test range of 15Hz to 60Hz:


### PR DESCRIPTION
This commit changed the syntax of some parameters 
https://github.com/MarlinFirmware/Marlin/pull/26848/files#diff-14808ae9863d17238d69b66567c42c44800690a8efdff27ada9de7eb0f4d2d54L136-L147

Parameter S became a simple on/off bool
Parameters X and Y where added to set the vibration compensator [input shaper] mode for X / Y axis