### PR TITLE
Update converter.html

### DIFF
--- a/_tools/u8glib/converter.html
+++ b/_tools/u8glib/converter.html
@@ -10,12 +10,16 @@ category:     [ tools ]
   <div class="row">
     <div class="col-lg-12" id="bitmap-converter">
       <h1>Bitmap Converter</h1>
-      <p>Convert image files and data into Marlin Boot Screens and Status Screen Logos for Graphical Displays. Dark colors show up as "on" pixels. Light colors will be transparent.</p>
+      <p>Convert image files into Marlin Boot Screens and Status Screen Logos for Graphical Displays.<br/>
+        Conversely, you can enter C/C++ binary/hex code. (<code class="bg-gray-200 p-1 rounded">B11110000</code>, <code class="bg-gray-200 p-1 rounded">0xFF</code>)<br/>
+        Dark colors show up as "on" pixels. Light colors will be transparent.</p>
       <div class="file-selector">
         <canvas id="preview-sm" width="32" height="32"></canvas>
         <canvas id="preview-lg" width="32" height="32"></canvas>
         <div id="err-box"></div>
-        <input type="text" id="pasted" size="30" autocomplete="off" />
+        <div style="margin-bottom: 10px;">
+          <textarea id="pasted" cols="30" rows="2" placeholder="Paste image, C/C++, or binary/hex here." autocomplete="off"></textarea>
+        </div>
         <input type="file" id="file-input" accept="image/*" />
         <div class="options">
           <label title="Marlin 1.x">&nbsp;<input type="radio" name="marlin-ver" value="1" />&nbsp;Marlin 1.x</label>

--- a/_tools/u8glib/converter.js
+++ b/_tools/u8glib/converter.js
@@ -45,8 +45,7 @@ var bitmap_converter = () => {
     };
   })($.event.fix);
 
-  var paste_message = 'Paste image or C/C++ here.',
-      preview_scale = 4,
+  var preview_scale = 4,
       max_size = [ 128, 64 ],
       pix_on  = [   0,   0,   0, 255 ],
       pix_off = [ 255, 255, 255,   0 ],
@@ -91,10 +90,6 @@ var bitmap_converter = () => {
 
       error_message = (msg) => {
         $err.text(msg).show(); console.log(msg);
-      },
-
-      restore_pasted_cpp_field = () => {
-        $pasted.val(paste_message).css('color', '');
       },
 
       /**
@@ -518,7 +513,6 @@ var bitmap_converter = () => {
       process_pasted_cpp = (cpp) => {
 
         prepare_for_new_image();
-        restore_pasted_cpp_field();
 
         // Get the split up bytes on all lines
         var lens = [], mostlens = [];
@@ -695,9 +689,6 @@ var bitmap_converter = () => {
   // Enable standard form field events
   prepare_for_new_image();
 
-  // Set a friendly message for C++ data paste
-  restore_pasted_cpp_field();
-
   // If the output is clicked, select all
   $output
     .on('mousedown mouseup', () => { return false; })
@@ -710,9 +701,7 @@ var bitmap_converter = () => {
       $this
         .val('')
         .css('color', '#F80')
-        .one('blur', restore_pasted_cpp_field)
         .one('paste', (e) => {
-          $this.css('color', '#FFFFFF00');
           convert_clipboard_to_image(e);
           $this.trigger('blur');
           return false;


### PR DESCRIPTION
Bitmap converter needs some updating.
It isn't initially apparent that it can reverse convert the code back into an image.

This **PR** updates the description, and slight tweak to layout.

Improves the 'Paste' text box and places into .html where it belongs honestly.
Made it a little wider, and moved 'Choose File' below the paste box.