### PR TITLE
Input shaping tool - Y Zeta script - fix final retract sign

### DIFF
--- a/_tools/input_shaping/freq-calibr.js
+++ b/_tools/input_shaping/freq-calibr.js
@@ -431,7 +431,7 @@ function generatePattern(settings) {
     zeta_y_script += go_to(x, y + 5, z, settings.travel_speed);
   }
   zeta_y_script += '; retract\n'
-  zeta_y_script += extrude(settings.retraction, settings.retrac_speed)
+  zeta_y_script += extrude(-settings.retraction, settings.retrac_speed)
 
   return { 'freq':freq_script, 'zeta_x':zeta_x_script, 'zeta_y':zeta_y_script };
 


### PR DESCRIPTION
Specific to Y axis zeta script generation.
Final `extrude` to do final retraction applies user input with no / `+` sign, where it should do it with `-` sign.
Example GCODE now live
```gcode
G0 X48.80 Y143.80 Z0.28 E190.81 F6000.0
; retract
G1 E191.81
```
expected / with fix
```gcode
G0 X48.80 Y143.80 Z0.28 E190.81 F6000.0
; retract
G1 E189.81
```

Freq and X already display this behavior, e.g. X zeta
```gcode
G0 X148.80 Y43.80 Z0.28 E190.81 F6000.0
; retract
G1 E189.81
```