### PR TITLE
H for axis sync

### DIFF
--- a/_gcode/M493.md
+++ b/_gcode/M493.md
@@ -28,7 +28,7 @@ parameters:
   - tag: 1
     description: Enabled
 
-- tag: T
+- tag: H
   optional: true
   description: Set the state for Axis Synchronization.
   values:


### PR DESCRIPTION
Make doc consistent with  Use H tag in FTM axis sync menu as in M493 [#28270 ](https://github.com/MarlinFirmware/Marlin/pull/28270)