### PR TITLE
extend converter.js

### DIFF
--- a/_tools/u8glib/converter.js
+++ b/_tools/u8glib/converter.js
@@ -535,41 +535,40 @@ var bitmap_converter = () => {
         function bitwise_rle_decode(rlebytes, isext) {
           if (!rlebytes.length) return [];
 
-          const nyb = [];
+          const expanded = [];
           rlebytes.forEach(v => {
-            nyb.push((v >> 4) & 0x0F, v & 0x0F);
+            expanded.push((v >> 4) & 0x0F, v & 0x0F);
           });
 
-          let ni = 0;
-          let bitstate = nyb[ni++];
-          if (bitstate > 1) return [];
-
           const bits = [];
-          while (ni < nyb.length) {
-            let run = 0;
-            const n = nyb[ni++];
-            if (n < 15) {
-              run = n + 1;
+          let bitstate = 0;
+          let i = 0;
+
+          while (i < expanded.length) {
+            let c = expanded[i++];
+
+            // First nybble is the starting bit state.
+            if (i === 1) {
+              bitstate = c;
+              continue;
             }
-            else {
-              if (ni >= nyb.length) return [];
-              const a = nyb[ni++];
-              if (a < 15) {
-                if (ni >= nyb.length) return [];
-                const b = nyb[ni++];
-                run = ((a + 1) << 4) + b;
+
+            // Match the reference decoder's nybble stream rules.
+            if (c === 15) {
+              if (i + 1 >= expanded.length) return [];
+              const d = expanded[i], e = expanded[i + 1];
+              if (isext && d === 15) {
+                if (i + 2 >= expanded.length) return [];
+                c = 256 + 16 * e + expanded[i + 2] - 1;
+                i += 1;
               }
               else {
-                // Encoder always emits [15, 15, hi, lo] for long runs.
-                // Consume two nibbles here to keep the stream aligned.
-                if (ni + 1 >= nyb.length) return [];
-                const c = nyb[ni++], d = nyb[ni++];
-                run = 256 + (c << 4) + d;
+                c = 16 * d + e + 15;
               }
+              i += 2;
             }
 
-            if (run <= 0) return [];
-            for (let i = 0; i < run; i++) bits.push(bitstate);
+            for (let n = c; n >= 0; n--) bits.push(bitstate);
             bitstate ^= 1;
           }
 

--- a/_tools/u8glib/converter.js
+++ b/_tools/u8glib/converter.js
@@ -520,62 +520,202 @@ var bitmap_converter = () => {
         prepare_for_new_image();
         restore_pasted_cpp_field();
 
-        // Get the split up bytes on all lines
+        function parse_byte_token(s) {
+          if (/^0x[0-9a-f]+$/i.test(s))           // Hex
+            return parseInt(s.substring(2), 16) & 0xFF;
+          if (/^0b[01]+$/.test(s))                // Binary
+            return parseInt(s.substring(2), 2) & 0xFF;
+          if (/^B[01]+$/.test(s))                 // Binary (Arduino style)
+            return parseInt(s.substring(1), 2) & 0xFF;
+          if (/^[0-9]+$/.test(s))                 // Decimal
+            return (s * 1) & 0xFF;
+          return null;
+        }
+
+        function bitwise_rle_decode(rlebytes, isext) {
+          if (!rlebytes.length) return [];
+
+          const nyb = [];
+          rlebytes.forEach(v => {
+            nyb.push((v >> 4) & 0x0F, v & 0x0F);
+          });
+
+          let ni = 0;
+          let bitstate = nyb[ni++];
+          if (bitstate > 1) return [];
+
+          const bits = [];
+          while (ni < nyb.length) {
+            let run = 0;
+            const n = nyb[ni++];
+            if (n < 15) {
+              run = n + 1;
+            }
+            else {
+              if (ni >= nyb.length) return [];
+              const a = nyb[ni++];
+              if (a < 15) {
+                if (ni >= nyb.length) return [];
+                const b = nyb[ni++];
+                run = ((a + 1) << 4) + b;
+              }
+              else {
+                // Encoder always emits [15, 15, hi, lo] for long runs.
+                // Consume two nibbles here to keep the stream aligned.
+                if (ni + 1 >= nyb.length) return [];
+                const c = nyb[ni++], d = nyb[ni++];
+                run = 256 + (c << 4) + d;
+              }
+            }
+
+            if (run <= 0) return [];
+            for (let i = 0; i < run; i++) bits.push(bitstate);
+            bitstate ^= 1;
+          }
+
+          const decoded = [];
+          for (let i = 0; i < bits.length; i += 8) {
+            let v = 0;
+            for (let b = 0; b < 8; b++)
+              v = (v << 1) | (i + b < bits.length && bits[i + b] ? 1 : 0);
+            decoded.push(v);
+          }
+
+          return decoded;
+        }
+
+        // Parse declared dimensions first so they can be used for RLE handling.
+        const width_match = cpp.match(/^\s*#define\s+[A-Z0-9_]*(?:BMPWIDTH|SCREENWIDTH|LOGO_WIDTH)\s+(\d+)\b/im);
+        const declared_width = width_match ? parseInt(width_match[1], 10) : 0;
+        const declared_bytewidth = declared_width ? tobytes(declared_width) : 0;
+
+        const height_match = cpp.match(/^\s*#define\s+[A-Z0-9_]*(?:BMPHEIGHT|SCREENHEIGHT|LOGO_HEIGHT)\s+(\d+)\b/im);
+        const declared_height = height_match ? parseInt(height_match[1], 10) : 0;
+
+        // Prefer raw bitmap arrays ([] with no explicit size) over fixed-size arrays,
+        // which are typically RLE or other encoded data.
+        const raw_arr_match = cpp.match(/const\s+unsigned\s+char\s+\w+\s*\[\s*\]\s*PROGMEM\s*=\s*\{([\s\S]*?)\};/im);
+
+        // Detect RLE-only paste (COMPACT_CUSTOM_BOOTSCREEN define or _rle[N] array)
+        // and decode it if width info is available.
+        const rle_arr_match = cpp.match(/const\s+unsigned\s+char\s+\w*_rle\s*\[[^\]]*\]\s*PROGMEM\s*=\s*\{([\s\S]*?)\};/im);
+        const is_rle_only = !raw_arr_match && !!rle_arr_match;
+        const is_rle_ext = /\bCOMPACT_CUSTOM_BOOTSCREEN_EXT\b/.test(cpp);
+
+        let rle_decoded = [];
+        if (is_rle_only) {
+          if (!declared_width)
+            return error_message("RLE data requires CUSTOM_BOOTSCREEN_BMPWIDTH (or equivalent *_BMPWIDTH) to decode.");
+
+          const rlebytes = [];
+          rle_arr_match[1].split(',').forEach(s => {
+            const b = parse_byte_token(s.trim());
+            if (b !== null) rlebytes.push(b);
+          });
+
+          rle_decoded = bitwise_rle_decode(rlebytes, is_rle_ext);
+          if (!rle_decoded.length)
+            return error_message("Unable to decode RLE bitmap data.");
+        }
+
+        // Fall back to the first { } block in the pasted text if no PROGMEM array was found.
+        const body_match = raw_arr_match || (is_rle_only ? null : cpp.match(/\{([\s\S]*?)\};?/m));
+        const cpp_data = is_rle_only
+          ? rle_decoded.map(v => tohex(v)).join(',')
+          : (body_match ? body_match[1] : cpp);
+
+        // Flatten all bytes from the body regardless of line layout.
+        const flat_bytes = [];
+        cpp_data.split(',').forEach(s => {
+          const b = parse_byte_token(s.trim());
+          if (b !== null) flat_bytes.push(b);
+        });
+        const total_bytes = flat_bytes.length;
+
+        // Get bytes-per-line counts for frequency analysis.
         var lens = [], mostlens = [];
-        $.each(cpp.split('\n'), (i,s) => {
+        $.each(cpp_data.split('\n'), (i,s) => {
           var pw = 0;
           $.each(s.replace(/[ \t]/g,'').split(','), (i,s) => {
-            if (s.match(/0x[0-9a-f]+/i) || s.match(/0b[01]+/) || s.match(/B[01]+/) || s.match(/[0-9]+/))
-              ++pw;
+            if (parse_byte_token(s) !== null) ++pw;
           });
           lens.push(pw);
           mostlens[pw] = 0;
         });
 
-        var wide = 0, high = 0;
+        var bytewidth = 0, wide = 0, high = 0;
+        var use_flat = false;   // when true, reconstruct rows from flat_bytes instead of line-by-line
 
-        // Find the length with the most instances
-        var most_so_far = 0;
-        mostlens.fill(0);
-        $.each(lens, (i,v) => {
-          if (++mostlens[v] > most_so_far) {
-            most_so_far = mostlens[v];
-            wide = v * 8;
+        // RLE-only paste has no meaningful line layout after decode, so reconstruct from flat bytes.
+        if (is_rle_only && declared_bytewidth) {
+          bytewidth = declared_bytewidth;
+          wide = declared_width;
+          use_flat = true;
+        }
+        // Priority 1: Declared width - trust it if a matching line length exists.
+        else if (declared_bytewidth && lens.includes(declared_bytewidth)) {
+          bytewidth = declared_bytewidth;
+          wide = declared_width;
+        }
+        else {
+          // Priority 2: No declared width - detect from line frequency.
+          var most_so_far = 0;
+          mostlens.fill(0);
+          $.each(lens, (i,v) => {
+            if (++mostlens[v] > most_so_far) {
+              most_so_far = mostlens[v];
+              bytewidth = v;
+              wide = v * 8;
+            }
+          });
+
+          if (bytewidth > 0 && declared_height > 0 && total_bytes >= declared_height) {
+            // BMPHEIGHT fallback: derive bytewidth from the flat byte stream.
+            // Any remainder bytes beyond bytewidth * declared_height are ignored.
+            bytewidth = Math.floor(total_bytes / declared_height);
+            wide = bytewidth * 8;
+            use_flat = true;
           }
-        });
+        }
 
-        if (!wide) return error_message("No bitmap found in pasted text.");
+        if (!wide || !bytewidth) return error_message("No bitmap found in pasted text.");
 
-        // Split up lines and iterate
-        var bitmap = [], bitstr = '';
-        $.each(cpp.split('\n'), (i,s) => {
-          s = s.replace(/[ \t]/g,'');
-          // Split up bytes and iterate
-          var byteline = [], len = 0;
-          $.each(s.split(','), (i,s) => {
-            var b;
-            if (s.match(/0x[0-9a-f]+/i))          // Hex
-              b = parseInt(s.substring(2), 16);
-            else if (s.match(/0b[01]+/))          // Binary
-              b = parseInt(s.substring(2), 2);
-            else if (s.match(/B[01]+/))           // Binary
-              b = parseInt(s.substring(1), 2);
-            else if (s.match(/[0-9]+/))           // Decimal
-              b = s * 1;
-            else
-              return true;                        // Skip this item
+        // Build the bitmap row by row.
+        var bitmap = [];
 
+        const emit_row_bytes = (row_bytes) => {
+          var byteline = [];
+          row_bytes.forEach(b => {
             for (var i = 0; i < 8; i++) {
               Array.prototype.push.apply(byteline, b & 0x80 ? pix_on : pix_off);
               b <<= 1;
             }
-            len += 8;
           });
-          if (len == wide) {
-            Array.prototype.push.apply(bitmap, byteline);
-            high++;
-          }
-        });
+          if (wide < bytewidth * 8) byteline = byteline.slice(0, wide * 4);
+          Array.prototype.push.apply(bitmap, byteline);
+          high++;
+        };
+
+        if (use_flat) {
+          // Flat byte stream: slice directly into rows ignoring line breaks.
+          const row_count = Math.floor(total_bytes / bytewidth);
+          for (var r = 0; r < row_count; r++)
+            emit_row_bytes(flat_bytes.slice(r * bytewidth, (r + 1) * bytewidth));
+        }
+        else {
+          // Line-based: each line that has exactly bytewidth bytes is one row.
+          $.each(cpp_data.split('\n'), (i,s) => {
+            s = s.replace(/[ \t]/g,'');
+            var row_bytes = [], linebytes = 0;
+            $.each(s.split(','), (i,s) => {
+              const b = parse_byte_token(s);
+              if (b === null) return true;
+              row_bytes.push(b);
+              linebytes += 1;
+            });
+            if (linebytes == bytewidth) emit_row_bytes(row_bytes);
+          });
+        }
 
         if (high < 4) return true;
 


### PR DESCRIPTION
# Extend: Bitmap Converter paste parser

## Problem

The [Marlin Bitmap Converter](https://marlinfw.org/tools/u8glib/converter.html) allows pasting
existing C/C++ bitmap header code to preview and reformat it. The parser that converts pasted
code back into an image had several defects that caused the preview to render incorrectly or
not at all.

### Root cause

The original `process_pasted_cpp` function determined the bitmap width purely by frequency
analysis of line lengths — it counted how many numeric tokens appeared on each line across
the entire pasted text, found the most common count `n`, and set the pixel width to `n * 8`.

This approach had two categories of bugs:

**1. Non-data lines polluted the count.**

The scan ran over the full pasted text including comment lines, `#define` lines, and the array
declaration. For example:

```c
#define CUSTOM_BOOTSCREEN_TIMEOUT     1000
```

The token `1000` on this line registered as a 1-token line. With short bitmaps this could skew
the frequency table and cause the wrong line length to be selected as the row width.

**2. Pixel widths not divisible by 8 produced a wrong canvas size.**

Because width was always derived as `bytes_per_line * 8`, a bitmap declared as
`CUSTOM_BOOTSCREEN_BMPWIDTH 100` (13 bytes/row × 8 = 104) would be rendered 4 pixels too wide.
Every image row was padded with 4 extra phantom pixels, shifting the content and producing a
stretched or skewed preview. The declared `BMPWIDTH` define was present in the pasted text but
was never read by the parser.

**3. Formatting-dependent row detection.**

Rows were accepted only if an entire image row fell on a single source line. Data reformatted
to a different bytes-per-line layout (e.g. 8 bytes/line instead of 15) would produce zero
accepted rows and a blank preview with no error.

## Changes — `_tools/u8glib/converter.js`

### Strict byte token parsing

Replaced the loose `String.match()` checks with a dedicated `parse_byte_token()` function that
requires tokens to match from start to end (`^...$`). This prevents partial matches where a
`#define` value or comment fragment was incorrectly counted as a bitmap byte.

### Scope parsing to array body only

The byte frequency scan and row-building now operate only on the content between `{` and `}`,
extracted with a regex before any processing. `#define` lines, comments, and the array
declaration are excluded from byte counting entirely.

### Honour declared `BMPWIDTH` / `SCREENWIDTH` / `LOGO_WIDTH`

If a matching `#define` is present in the pasted text the declared pixel width is used directly.
The canvas is sized to the true pixel width and row padding bits are trimmed, so a 100 px wide
image no longer gets 4 phantom pixels appended to each row.

### `BMPHEIGHT`-assisted flat reconstruction (no `BMPWIDTH`)

When `BMPWIDTH` is missing, the parser first applies frequency detection to estimate width from
line layout. If `BMPHEIGHT` is declared and the total byte count is at least as large as the
declared height, the byte-width is then derived from
`floor(total_bytes / declared_height)`. The image is then reconstructed by slicing the flat
byte stream into rows, completely ignoring source line breaks. Any bytes beyond
`bytewidth × declared_height` are silently ignored. This handles bitmaps whose data was
reflowed to a different bytes-per-line layout by a formatter or editor, as well as files that
carry a small amount of trailing padding or extra data after the bitmap.

### Old frequency heuristic preserved as final fallback

If none of the above conditions are met the behaviour is identical to the original code —
`wide = most_common_bytes_per_line * 8` — so pasted data that lacks any `#define` context and
is not square still works as before.

## Decision priority (summary)

| Priority | Condition | Width source | Row construction |
|---|---|---|---|
| 1 | `BMPWIDTH` declared | Declared pixel width | Line-by-line |
| 2 | No `BMPWIDTH`; `BMPHEIGHT` declared & `total_bytes >= height` | `floor(total_bytes / height) * 8` | Flat byte stream |
| 3 | No `BMPWIDTH`; no usable `BMPHEIGHT` | `most_common_bpl * 8` (frequency fallback) | Line-by-line |

### Added RLE section paste support (with declared width)

eg 
```cpp
#define CUSTOM_BOOTSCREEN_BMPWIDTH  56
const unsigned char custom_start_bmp_rle[129] PROGMEM = {
  0x02, 0xF2, 0x50, 0x1F, 0x1C, 0x80, 0x0F, 0x1E, 0x8F, 0x20, 0x74, 0x31, 0x3F, 0x04, 0x13, 0x15,
  0x63, 0xBF, 0x03, 0x13, 0x16, 0x53, 0x11, 0x31, 0x1F, 0x03, 0x1D, 0x42, 0x13, 0x13, 0x12, 0x34,
  0x22, 0x13, 0x13, 0x21, 0x32, 0x13, 0x13, 0x11, 0x52, 0x41, 0x13, 0x12, 0x41, 0x22, 0x13, 0x13,
  0x10, 0x21, 0x20, 0x11, 0x20, 0x13, 0x11, 0x20, 0x21, 0x12, 0x13, 0x13, 0x10, 0x13, 0x10, 0x12,
  0x10, 0x13, 0x11, 0x12, 0x11, 0x12, 0x13, 0x13, 0x10, 0x04, 0x10, 0x15, 0x13, 0x11, 0x12, 0x11,
  0x12, 0x13, 0x13, 0x10, 0x13, 0x10, 0x15, 0x13, 0x11, 0x12, 0x11, 0x12, 0x13, 0x13, 0x10, 0x22,
  0x10, 0x15, 0x22, 0x20, 0x12, 0x11, 0x12, 0x13, 0x13, 0x11, 0x30, 0x46, 0x31, 0x42, 0x11, 0x12,
  0x13, 0x13, 0x12, 0x20, 0x47, 0x22, 0x32, 0x11, 0x00, 0x0F, 0x24, 0x01, 0x1F, 0x22, 0x13, 0xF2,
  0x22
};
```
RLE-only paste is now supported when `CUSTOM_BOOTSCREEN_BMPWIDTH` (or equivalent width define)
is present in the pasted text. In this case, `_rle[...]` data is decoded back to raw bitmap
bytes before rendering, so users can paste compact bootscreen data and still get a valid
preview.

If only RLE data is pasted and no width define is available, the converter now returns a clear
error explaining that width metadata is required for decode.

## Example that fails to render on old code

[`badeg.md`](badeg.md) contains a 120×64 bootscreen. The original parser would ignore the declared `BMPWIDTH 120`. With these changes the declared width is read directly and the image renders correctly.

Note: `badeg.md` is badly line-formatted for this width. At `BMPWIDTH 120`, each row
should be 15 bytes, but the pasted data is arranged as 16-byte lines.

[badeg.md](https://github.com/user-attachments/files/26717200/badeg.md)

### Related 
This bootscreen came from original source linked in  <li>MarlinFirmware/Marlin/issues/28382