### PR TITLE
Update M420. Correct C, extend T and add examples

### DIFF
--- a/_gcode/M420.md
+++ b/_gcode/M420.md
@@ -18,19 +18,25 @@ notes: |
       - With `ENABLE_LEVELING_AFTER_G28` leveling will always be enabled after `G28`.
       - With `RESTORE_LEVELING_AFTER_G28` leveling is restored to whatever state it was in before `G28`.
   - For multi-axis machines (`I_DRIVER_TYPE` defined) without implementation of inverse kinematics, bed leveling produces wrong results while the toolhead is not oriented vertical and perpendicular to the bed and must be turned off with `M420 S0`.
+  - Remaining nuance (advanced): If firmware is built with `M420_C_USE_MEAN` in M420 source, `C` centering uses arithmetic mean instead of midpoint math.
 
 parameters:
 
 - tag: L
   optional: true
   requires: AUTO_BED_LEVELING_UBL, EEPROM_SETTINGS
-  description: Load mesh from EEPROM index
+  description: |
+    Load a UBL mesh from EEPROM slot.
+    - If no slot is given, the current UBL storage slot is used.
   values:
   - type: int
 
 - tag: S
   optional: true
-  description: Set enabled or disabled. A valid mesh is required to enable bed leveling. If the mesh is invalid / incomplete leveling will not be enabled.
+  description: |
+    Set leveling enabled or disabled.
+    - A valid mesh is required to enable leveling.
+    - With `MARLIN_DEV_MODE`, `S2` creates a simple random mesh and enables leveling.
   values:
   - type: bool
 
@@ -42,12 +48,15 @@ parameters:
 
 - tag: T
   optional: true
-  description: Format to print the mesh data
+  requires: AUTO_BED_LEVELING_UBL
+  description: Format for UBL mesh map output (used with `L` and/or `V`)
   values:
   - tag: 0
     description: Human readable
   - tag: 1
     description: CSV
+  - tag: 2
+    description: LCD
   - tag: 4
     description: Compact
 
@@ -64,12 +73,34 @@ parameters:
 
 - tag: C
   optional: true
-  description: Center the mesh on the mean of the lowest and highest points
+  description: |
+    Re-center the current mesh Z values around zero.
+    - `C` (or `C0`) re-centers with no extra offset.
+    - `C<value>` also applies a global offset to the whole mesh.
+    - Works only with a valid mesh.
   values:
-  - type: bool
+  - type: float
+
+examples:
+- pre: Report current leveling state
+  code: M420
+- pre: Enable leveling
+  code: M420 S1
+- pre: Disable leveling
+  code: M420 S0
+- pre: Set fade height to 10mm
+  code: M420 Z10
+- pre: Re-center mesh values (C defaults to 0)
+  code: M420 C
+- pre: Re-center mesh values and apply an additional offset
+  code: M420 C0.05
+- pre: Load UBL mesh slot 0 and show it in compact format
+  code: M420 L0 V T4
+- pre: Show UBL mesh in LCD-style format
+  code: M420 V T2
 
 ---
 
-Set/report bed leveling state. For mesh-based leveling systems use `Z` parameter to set the Z Fade Height.
+Set/report bed leveling state. Use `Z` to set the Fade Height.
 
-With `AUTO_BED_LEVELING_UBL` you can use `L` to load a mesh from EEPROM.
+With `AUTO_BED_LEVELING_UBL` you can use `L` to load a mesh from EEPROM and `T` to choose map output format.

--- a/_gcode/M420.md
+++ b/_gcode/M420.md
@@ -103,6 +103,8 @@ examples:
 
 ---
 
-Set/report bed leveling state. Use `Z` to set the Fade Height.
+Set/report the Bed Leveling state and Mesh values, when applicable.
 
-With `AUTO_BED_LEVELING_UBL` you can use `L` to load a mesh from EEPROM and `T` to choose map output format.
+With `AUTO_BED_LEVELING_UBL` you can load and save a mesh from EEPROM and set mesh report format.
+
+With mesh-based leveling you can set a Fade Height to gradually reduce bed leveling correction to zero, so the remaining print job is free of bed leveling compensation artifacts.

--- a/_gcode/M420.md
+++ b/_gcode/M420.md
@@ -73,13 +73,15 @@ parameters:
 
 - tag: C
   optional: true
+  requires: HAS_MESH
   description: |
-    Re-center the current mesh Z values around zero.
-    - `C` (or `C0`) re-centers with no extra offset.
-    - `C<value>` also applies a global offset to the whole mesh.
+    - Re-center the all mesh Z values, then subtract the given negative offset (default 0).
+       - UBL: Center on the Mean Average (sum / count).
+       - Others: Center on the Midrange ((highest - lowest) / 2).
     - Works only with a valid mesh.
   values:
   - type: float
+  - tag: negative_offset
 
 examples:
 - pre: Report current leveling state

--- a/_gcode/M420.md
+++ b/_gcode/M420.md
@@ -3,7 +3,7 @@ tag: m0420
 title: Bed Leveling State
 brief: Set/report bed leveling state and parameters
 author: thinkyhead
-contrib: sustmi, shitcreek
+contrib: sustmi, shitcreek, ellensp
 
 group: motion
 requires: AUTO_BED_LEVELING_*|MESH_BED_LEVELING


### PR DESCRIPTION
# Update M420 documentation

## Summary
This PR improves `_gcode/M420.md` by correcting parameter behavior details and adding clearer usage guidance.

## What changed in M420.md
- Added an advanced note for `M420_C_USE_MEAN`, clarifying how `C` centering may use arithmetic mean instead of midpoint math.
- Expanded `L` parameter description to explain UBL EEPROM slot loading and default slot behavior.
- Expanded `S` parameter description to clarify enable/disable behavior, valid mesh requirement, and `MARLIN_DEV_MODE` `S2` behavior.
- Added `requires: AUTO_BED_LEVELING_UBL` to `T` and clarified that `T` controls UBL mesh map output formatting.
- Added `T2` format option (`LCD`) to the `T` parameter values.
- Corrected `C` parameter definition from boolean to float.
- Rewrote `C` description to explain `C`, `C0`, and `C<value>` behavior, including valid mesh requirement.
- Added practical command examples for reporting state, enabling/disabling, fade height, re-centering, and UBL mesh output formats.
- Updated the body text for clearer wording around Fade Height and combined `L` + `T` usage for UBL.

## Impact
- Documentation now better matches firmware behavior for `C` and `T`.
- Users have clearer examples for common `M420` workflows.


## Screenshots of what it now looks like
<img width="1049" height="655" alt="Screenshot from 2026-04-18 23-06-17" src="https://github.com/user-attachments/assets/67235cf9-1537-4dce-8565-eb8e3a2187e5" />
<img width="1049" height="890" alt="Screenshot from 2026-04-18 22-55-26" src="https://github.com/user-attachments/assets/2136379d-e3e2-4199-a968-42072d71ce1c" />
<img width="1049" height="890" alt="Screenshot from 2026-04-18 22-55-43" src="https://github.com/user-attachments/assets/3fa70103-5e09-44cf-90a9-0530010e2447" />
