### PR TITLE
Clarify file position as being byte offsets (M24, M26)

### DIFF
--- a/_gcode/M024.md
+++ b/_gcode/M024.md
@@ -17,7 +17,7 @@ parameters:
 
 - tag: S
   optional: true
-  description: Position in file to resume from (requires `POWER_LOSS_RECOVERY`)
+  description: Position in file (byte offset) to resume from (requires `POWER_LOSS_RECOVERY`)
   values:
   - tag: pos
     type: long

--- a/_gcode/M026.md
+++ b/_gcode/M026.md
@@ -13,7 +13,7 @@ parameters:
 
 - tag: S
   optional: true
-  description: Next file read position to set
+  description: Next file read position to set (byte offset)
   values:
   - tag: pos
     type: long


### PR DESCRIPTION
I was trying to resume printing from a byte offset in file. When I read the description, it wasn't clear what "position" meant, I almost misinterpret it as line number.

I would like to make it clear for future readers.