### PR TITLE
Fix incomplete boards list rendering

### DIFF
--- a/_includes/boards.md
+++ b/_includes/boards.md
@@ -62,7 +62,7 @@ If you're developing a custom board, try to use common pinouts as much as possib
 <table class="table table-condensed table-striped">
 <tr><th>Name</th><th>Description</th><th>Since</th></tr>
 {% for board in item.boards %}
-<tr{% if board.class %} class="{{ board.class }}"{% endif %}><td><code>BOARD_{{ board.name }}{% if board.old[0].name %}</code><br><em>(<code>BOARD_{{ board.old[0].name }}</code>)</em>{% endif %}</td><td>{{ board.brief }}</td><td>{% if board.since %}{{ board.since }}{% endif %}{% if board.old[0].since %}<br><em>({{ board.old[0].since }})</em>{% endif %}</td></tr>
+<tr{% if board.class %} class="{{ board.class }}"{% endif %}><td><code>BOARD_{{ board.name }}</code>{% if board.old[0].name %}<br><em>(<code>BOARD_{{ board.old[0].name }}</code>)</em>{% endif %}</td><td>{{ board.brief }}</td><td>{% if board.since %}{{ board.since }}{% endif %}{% if board.old[0].since %}<br><em>({{ board.old[0].since }})</em>{% endif %}</td></tr>
 {% endfor %}
 </table>
 {% endfor %}


### PR DESCRIPTION
## Summary

Fix the hardware boards pages https://marlinfw.org/docs/hardware/boards.html#boards-list so the complete list from `_data/boards.yml` is rendered.

## What was found

`MINIRAMBO` and the later board groups were present and valid in the YAML data. The board-name `<code>` tag in the Liquid template was only closed for entries with a legacy board name. This produced malformed HTML, which caused Kramdown to stop rendering the list correctly after the early groups.

## Changes

Close the primary board-name `<code>` tag for every board before conditionally rendering the legacy board name.

## Verification

- Ran a clean Jekyll build successfully.
- Confirmed the generated and locally served pages include `BOARD_MINIRAMBO`.
- Confirmed all 441 board identifiers are rendered.