### PR TITLE
No theme change while focusing on input

### DIFF
--- a/assets/javascript/custom.js
+++ b/assets/javascript/custom.js
@@ -215,6 +215,7 @@ $(function() {
 
   // Watch for a certain keypress to toggle dark mode
   $(document).keypress(function(e) {
+    if ($(e.target).is('input, textarea, [contenteditable="true"]')) return;
     const c = String.fromCharCode(e.which).toLowerCase();
     if (c == 'd' || c == 'n') // 'd' or 'n' key
       userToggleDarkMode();


### PR DESCRIPTION
<img width="684" height="381" alt="image" src="https://github.com/user-attachments/assets/bcf81260-be95-4a30-afe0-9f03ab18fcf0" />

Pressing d/n on input textbox should not switch dark/light mode 